### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,6 @@ iOSInjectionProject/
 
 # Built application files
 *.apk
-*.aar
 *.ap_
 *.aab
 


### PR DESCRIPTION
third party libraries sometimes need to be included locally in the repo, such as PresenceViewer when it's a specific version built from source