### PR TITLE
Feature/copyright update

### DIFF
--- a/Android/app/src/androidTest/java/live/dittolive/chat/ExampleInstrumentedTest.kt
+++ b/Android/app/src/androidTest/java/live/dittolive/chat/ExampleInstrumentedTest.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/androidTest/java/live/dittolive/chat/ExampleInstrumentedTest.kt
+++ b/Android/app/src/androidTest/java/live/dittolive/chat/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/AndroidManifest.xml
+++ b/Android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/AuthCallback.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/AuthCallback.kt
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/DittoHandler.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/DittoHandler.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/DittoHandler.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/DittoHandler.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/NavActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/NavActivity.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/NavActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/NavActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
@@ -50,13 +50,13 @@ class SplashActivity : AppCompatActivity() {
   private fun setupDitto() {
     val androidDependencies = DefaultAndroidDittoDependencies(this)
     DittoLogger.minimumLogLevel = DittoLogLevel.DEBUG
-    DittoHandler.ditto = Ditto(
+    ditto = Ditto(
       androidDependencies,
       DittoIdentity.OfflinePlayground(androidDependencies, BuildConfig.DITTO_APP_ID)
     )
-    DittoHandler.ditto.setOfflineOnlyLicenseToken(BuildConfig.DITTO_LICENSE_TOKEN)
+    ditto.setOfflineOnlyLicenseToken(BuildConfig.DITTO_LICENSE_TOKEN)
     // Disable sync with V3
         ditto.disableSyncWithV3()
-    DittoHandler.ditto.startSync()
+    ditto.startSync()
   }
 }

--- a/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
@@ -1,9 +1,8 @@
 /*
- * Copyright (c) 2018 Razeware LLC
- *
+ * Copyright (c) 2018-2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
+ * of this software and associated documentation files (the “Software”), to deal
+ * In the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
@@ -11,15 +10,11 @@
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- * Notwithstanding the foregoing, you may not use, copy, modify, merge, publish,
- * distribute, sublicense, create a derivative work, and/or sell copies of the
- * Software in any work that is designed, intended, or marketed for pedagogical or
- * instructional purposes related to programming, coding, application development,
- * or information technology.  Permission for such use, copying, modification,
- * merger, publication, distribution, sublicensing, creation of derivative works,
- * or sale is expressly withheld.
+ * This project and source code may use libraries or frameworks that are
+ * released under various Open-Source licenses. Use of those libraries and
+ * frameworks are governed by their own individual licenses.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER

--- a/Android/app/src/main/java/live/dittolive/chat/app/DittoChatApp.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/DittoChatApp.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/app/DittoChatApp.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/DittoChatApp.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/DataStoreModule.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/DataStoreModule.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/DataStoreModule.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/DataStoreModule.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/RepositoryModule.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/RepositoryModule.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/RepositoryModule.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/RepositoryModule.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/UserPreferencesRepositoryModule.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/UserPreferencesRepositoryModule.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/UserPreferencesRepositoryModule.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/app/dependencyinjection/UserPreferencesRepositoryModule.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/auth/AuthCallback.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/auth/AuthCallback.kt
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/components/AnimatingFabContent.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/AnimatingFabContent.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/components/AnimatingFabContent.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/AnimatingFabContent.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/components/BaseLineHeightModifier.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/BaseLineHeightModifier.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/components/BaseLineHeightModifier.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/BaseLineHeightModifier.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatAppBar.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatAppBar.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatAppBar.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatAppBar.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatDrawer.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatDrawer.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatDrawer.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatDrawer.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatIcon.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatIcon.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatIcon.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatIcon.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatScaffold.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatScaffold.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatScaffold.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatScaffold.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/BackHandler.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/BackHandler.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/BackHandler.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/BackHandler.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/Conversation.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/Conversation.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/Conversation.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/Conversation.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationFragment.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationFragment.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationFragment.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationFragment.kt
@@ -1,17 +1,26 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright (c) 2023 DittoLive.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * In the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * This project and source code may use libraries or frameworks that are
+ * released under various Open-Source licenses. Use of those libraries and
+ * frameworks are governed by their own individual licenses.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 package live.dittolive.chat.conversation

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationFragment.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationUiState.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationUiState.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationUiState.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/ConversationUiState.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/JumpToBottom.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/JumpToBottom.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/JumpToBottom.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/JumpToBottom.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/MessageFormatter.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/MessageFormatter.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/MessageFormatter.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/MessageFormatter.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/UserInput.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/UserInput.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/conversation/UserInput.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/conversation/UserInput.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/Constants.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/Constants.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/Constants.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/Constants.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/FakeData.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/FakeData.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/FakeData.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/FakeData.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/DateExtensions.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/DateExtensions.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/DateExtensions.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/DateExtensions.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/MessageUiModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/MessageUiModel.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/MessageUiModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/MessageUiModel.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/Room.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/Room.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/Room.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/Room.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/RoomMessages.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/RoomMessages.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/RoomMessages.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/RoomMessages.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/User.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/User.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/User.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/User.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/UserPreferences.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/UserPreferences.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/UserPreferences.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/UserPreferences.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/Repository.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/Repository.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/Repository.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/Repository.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepository.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepository.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepository.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepository.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepositoryImpl.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/UserPreferencesRepositoryImpl.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerActivity.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerActivity.kt
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2023 DittoLive.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * In the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * This project and source code may use libraries or frameworks that are
+ * released under various Open-Source licenses. Use of those libraries and
+ * frameworks are governed by their own individual licenses.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package live.dittolive.chat.presenceviewer
 
 import android.os.Bundle

--- a/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerActivity.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerComposable.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerComposable.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerComposable.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/presenceviewer/PresenceViewerComposable.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/profile/Previews.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/Previews.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/profile/Previews.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/Previews.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
@@ -1,17 +1,26 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright (c) 2023 DittoLive.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * In the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * This project and source code may use libraries or frameworks that are
+ * released under various Open-Source licenses. Use of those libraries and
+ * frameworks are governed by their own individual licenses.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 package live.dittolive.chat.profile

--- a/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/profile/ProfileViewModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/ProfileViewModel.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/profile/ProfileViewModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/ProfileViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/router/BackButtonHandler.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/router/BackButtonHandler.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2022-2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/router/BackButtonHandler.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/router/BackButtonHandler.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022-2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/screens/ColumnScreen.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/screens/ColumnScreen.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/screens/ColumnScreen.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/screens/ColumnScreen.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/screens/PermissionsAndChatScreen.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/screens/PermissionsAndChatScreen.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/screens/PermissionsAndChatScreen.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/screens/PermissionsAndChatScreen.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/theme/Color.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/theme/Color.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/theme/Color.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/theme/Color.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/theme/Themes.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/theme/Themes.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/theme/Themes.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/theme/Themes.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/theme/Typography.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/theme/Typography.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/theme/Typography.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/theme/Typography.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/utilities/UiExtras.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/utilities/UiExtras.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/java/live/dittolive/chat/utilities/UiExtras.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/utilities/UiExtras.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/viewmodel/MainViewModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/viewmodel/MainViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021-2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/java/live/dittolive/chat/viewmodel/MainViewModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/viewmodel/MainViewModel.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2021-2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ditto_logo.xml
+++ b/Android/app/src/main/res/drawable/ditto_logo.xml
@@ -1,3 +1,28 @@
+<!--
+  ~ Copyright (c) 2023 DittoLive.
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ In the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ This project and source code may use libraries or frameworks that are
+  ~ released under various Open-Source licenses. Use of those libraries and
+  ~ frameworks are governed by their own individual licenses.
+  ~
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="350dp"
     android:height="350dp"

--- a/Android/app/src/main/res/drawable/ditto_logo.xml
+++ b/Android/app/src/main/res/drawable/ditto_logo.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ditto_logo.xml
+++ b/Android/app/src/main/res/drawable/ditto_logo.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/ditto_logo_white.xml
+++ b/Android/app/src/main/res/drawable/ditto_logo_white.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ditto_logo_white.xml
+++ b/Android/app/src/main/res/drawable/ditto_logo_white.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/dittochat_logo.xml
+++ b/Android/app/src/main/res/drawable/dittochat_logo.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/dittochat_logo.xml
+++ b/Android/app/src/main/res/drawable/dittochat_logo.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/ic_dittochat.xml
+++ b/Android/app/src/main/res/drawable/ic_dittochat.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ic_dittochat.xml
+++ b/Android/app/src/main/res/drawable/ic_dittochat.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/ic_dittochat_back.xml
+++ b/Android/app/src/main/res/drawable/ic_dittochat_back.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ic_dittochat_back.xml
+++ b/Android/app/src/main/res/drawable/ic_dittochat_back.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/ic_dittochat_front.xml
+++ b/Android/app/src/main/res/drawable/ic_dittochat_front.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ic_dittochat_front.xml
+++ b/Android/app/src/main/res/drawable/ic_dittochat_front.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/Android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/Android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/ic_launcher_monochrome_foreground.xml
+++ b/Android/app/src/main/res/drawable/ic_launcher_monochrome_foreground.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/ic_launcher_monochrome_foreground.xml
+++ b/Android/app/src/main/res/drawable/ic_launcher_monochrome_foreground.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/drawable/splash_background.xml
+++ b/Android/app/src/main/res/drawable/splash_background.xml
@@ -4,7 +4,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/drawable/splash_background.xml
+++ b/Android/app/src/main/res/drawable/splash_background.xml
@@ -3,7 +3,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/layout/activity_presence_viewer.xml
+++ b/Android/app/src/main/res/layout/activity_presence_viewer.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/layout/activity_presence_viewer.xml
+++ b/Android/app/src/main/res/layout/activity_presence_viewer.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2023 DittoLive.
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ In the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ This project and source code may use libraries or frameworks that are
+  ~ released under various Open-Source licenses. Use of those libraries and
+  ~ frameworks are governed by their own individual licenses.
+  ~
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"

--- a/Android/app/src/main/res/layout/activity_presence_viewer.xml
+++ b/Android/app/src/main/res/layout/activity_presence_viewer.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/layout/fragment_profile.xml
+++ b/Android/app/src/main/res/layout/fragment_profile.xml
@@ -1,17 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright 2022 Google LLC
+  ~ Copyright (c) 2023 DittoLive.
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ In the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
   ~
-  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~ This project and source code may use libraries or frameworks that are
+  ~ released under various Open-Source licenses. Use of those libraries and
+  ~ frameworks are governed by their own individual licenses.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
   -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/Android/app/src/main/res/layout/fragment_profile.xml
+++ b/Android/app/src/main/res/layout/fragment_profile.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/layout/fragment_profile.xml
+++ b/Android/app/src/main/res/layout/fragment_profile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/layout/nav_host.xml
+++ b/Android/app/src/main/res/layout/nav_host.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/layout/nav_host.xml
+++ b/Android/app/src/main/res/layout/nav_host.xml
@@ -1,18 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright 2020 The Android Open Source Project
+  ~ Copyright (c) 2023 DittoLive.
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ In the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~ This project and source code may use libraries or frameworks that are
+  ~ released under various Open-Source licenses. Use of those libraries and
+  ~ frameworks are governed by their own individual licenses.
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
   -->
 
 

--- a/Android/app/src/main/res/layout/nav_host.xml
+++ b/Android/app/src/main/res/layout/nav_host.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2023 DittoLive.
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ In the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ This project and source code may use libraries or frameworks that are
+  ~ released under various Open-Source licenses. Use of those libraries and
+  ~ frameworks are governed by their own individual licenses.
+  ~
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome_round.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome_round.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome_round.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome_round.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2023 DittoLive.
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ In the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ This project and source code may use libraries or frameworks that are
+  ~ released under various Open-Source licenses. Use of those libraries and
+  ~ frameworks are governed by their own individual licenses.
+  ~
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_monochrome_background"/>
     <foreground android:drawable="@drawable/ic_launcher_monochrome_foreground"/>

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome_round.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_monochrome_round.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/Android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,4 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2023 DittoLive.
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ In the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ This project and source code may use libraries or frameworks that are
+  ~ released under various Open-Source licenses. Use of those libraries and
+  ~ frameworks are governed by their own individual licenses.
+  ~
+  ~ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>

--- a/Android/app/src/main/res/navigation/dittonav.xml
+++ b/Android/app/src/main/res/navigation/dittonav.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/navigation/dittonav.xml
+++ b/Android/app/src/main/res/navigation/dittonav.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values-night/colors.xml
+++ b/Android/app/src/main/res/values-night/colors.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values-night/colors.xml
+++ b/Android/app/src/main/res/values-night/colors.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values-night/themes.xml
+++ b/Android/app/src/main/res/values-night/themes.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values-night/themes.xml
+++ b/Android/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values-v23/font_certs.xml
+++ b/Android/app/src/main/res/values-v23/font_certs.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values-v23/font_certs.xml
+++ b/Android/app/src/main/res/values-v23/font_certs.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values-v23/themes.xml
+++ b/Android/app/src/main/res/values-v23/themes.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values-v23/themes.xml
+++ b/Android/app/src/main/res/values-v23/themes.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values-v27/themes.xml
+++ b/Android/app/src/main/res/values-v27/themes.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values-v27/themes.xml
+++ b/Android/app/src/main/res/values-v27/themes.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values/colors.xml
+++ b/Android/app/src/main/res/values/colors.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values/ic_launcher_background.xml
+++ b/Android/app/src/main/res/values/ic_launcher_background.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values/ic_launcher_background.xml
+++ b/Android/app/src/main/res/values/ic_launcher_background.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values/ic_launcher_monochrome_background.xml
+++ b/Android/app/src/main/res/values/ic_launcher_monochrome_background.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values/ic_launcher_monochrome_background.xml
+++ b/Android/app/src/main/res/values/ic_launcher_monochrome_background.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values/styles.xml
+++ b/Android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values/styles.xml
+++ b/Android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/values/themes.xml
+++ b/Android/app/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/values/themes.xml
+++ b/Android/app/src/main/res/values/themes.xml
@@ -2,7 +2,7 @@
 <!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/xml/backup_rules.xml
+++ b/Android/app/src/main/res/xml/backup_rules.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/xml/backup_rules.xml
+++ b/Android/app/src/main/res/xml/backup_rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/Android/app/src/main/res/xml/data_extraction_rules.xml
@@ -2,7 +2,7 @@
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the “Software”), to deal
-  ~ In the Software without restriction, including without limitation the rights
+  ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is
   ~ furnished to do so, subject to the following conditions:

--- a/Android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/Android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2023 DittoLive.
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
-  ~ of this software and associated documentation files (the “Software”), to deal
+  ~ of this software and associated documentation files (the "Software"), to deal
   ~ in the Software without restriction, including without limitation the rights
   ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
   ~ copies of the Software, and to permit persons to whom the Software is

--- a/Android/app/src/test/java/live/dittolive/chat/ExampleUnitTest.kt
+++ b/Android/app/src/test/java/live/dittolive/chat/ExampleUnitTest.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the “Software”), to deal
- * In the Software without restriction, including without limitation the rights
+ * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:

--- a/Android/app/src/test/java/live/dittolive/chat/ExampleUnitTest.kt
+++ b/Android/app/src/test/java/live/dittolive/chat/ExampleUnitTest.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023 DittoLive.
  * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the “Software”), to deal
+ * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is

--- a/Android/gradle.properties
+++ b/Android/gradle.properties
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2023 DittoLive.
 # Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the ?Software?), to deal
+# of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is

--- a/Android/gradle.properties
+++ b/Android/gradle.properties
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 DittoLive.
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the ?Software?), to deal
-# In the Software without restriction, including without limitation the rights
+# in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:

--- a/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2023 DittoLive.
 # Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the ?Software?), to deal
+# of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is

--- a/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 # Copyright (c) 2023 DittoLive.
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the ?Software?), to deal
-# In the Software without restriction, including without limitation the rights
+# in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:


### PR DESCRIPTION
updated copyright template and applied to entire project
also removes reference to authentication, this seems to have been merged in by accident? authentication is separate branch that should not be merged to main