### PR TITLE
Fix occasional reappearance of room when archiving

### DIFF
--- a/iOS/DittoChat/Data/DataManager.swift
+++ b/iOS/DittoChat/Data/DataManager.swift
@@ -16,7 +16,6 @@ protocol LocalDataInterface {
     
     var privateRoomsPublisher: AnyPublisher<[Room], Never> { get }
     func addPrivateRoom(_ room: Room)
-    func removePrivateRoom(roomId: String)
     
     var archivedPrivateRoomsPublisher: AnyPublisher<[Room], Never> { get }
     func archivePrivateRoom(_ room: Room)

--- a/iOS/DittoChat/Data/LocalStoreService.swift
+++ b/iOS/DittoChat/Data/LocalStoreService.swift
@@ -65,12 +65,6 @@ class LocalStoreService: LocalDataInterface {
         privateRoomsSubject.send(rooms)
     }
     
-    func removePrivateRoom(roomId: String) {
-        let roomsData = removeRoom(roomId: roomId, from: &defaults.privateRooms)
-        let rooms = defaults.decodeRoomsFromData(roomsData)
-        privateRoomsSubject.send(rooms)
-    }
-    
     func archivePrivateRoom(_ room: Room) {
         // remove from privateRooms
         var roomsData = removeRoom(roomId: room.id, from: &defaults.privateRooms)
@@ -80,7 +74,6 @@ class LocalStoreService: LocalDataInterface {
         // add to archivedPrivateRooms
         roomsData = addRoom(room, to: &defaults.archivedPrivateRooms)
         rooms = defaults.decodeRoomsFromData(roomsData)
-        
         archivedPrivateRoomsSubject.send(rooms)
     }
     


### PR DESCRIPTION
The issue of occasional flickering and reappearance of a private room in the rooms list after swiping to archive was because stop() was not invoked on the observerLocal instance, created when a private room was joined by QR code. This caused its callback closure to fire for every update on the room instance, including when it was archived, albeit occasionally because of thread race.