### PR TITLE
Fix room optional property initializer

### DIFF
--- a/iOS/DittoChat/Models/Room.swift
+++ b/iOS/DittoChat/Models/Room.swift
@@ -27,7 +27,7 @@ extension Room {
         self.name = document[nameKey].stringValue
         self.messagesId = document[messagesIdKey].stringValue
         self.isPrivate = document[isPrivateKey].boolValue
-        self.collectionId = document[collectionIdKey].stringValue
+        self.collectionId = document[collectionIdKey].string
         self.createdBy = document[createdByKey].stringValue
         self.createdOn = DateFormatter.isoDate.date(from: document[createdOnKey].stringValue) ?? Date()
     }


### PR DESCRIPTION
`collectionId` is an optional property of the Room model. The init function taking a DittoDocument argument used syntax returning a non-optional String. This had never failed (crashed) in development and testing, but this commit changes to use the DittoDocumentPath syntax for returning optional String.