### PR TITLE
Default Basic Chat feature

### DIFF
--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "a7cc8dda460487e439e628b0a5044e86a983ad64",
-        "version" : "4.1.0"
+        "revision" : "186f68c30bd8e5837357ed97dc3e97019a1cbc56",
+        "version" : "4.2.1"
       }
     },
     {

--- a/iOS/DittoChat/Data/DataManager.swift
+++ b/iOS/DittoChat/Data/DataManager.swift
@@ -29,6 +29,9 @@ protocol LocalDataInterface {
     
     var currentUserId: String? { get set }
     var currentUserIdPublisher: AnyPublisher<String?, Never> { get }
+    
+    var basicChat: Bool { get set }
+    var basicChatPublisher: AnyPublisher<Bool, Never> { get }
 }
 
 protocol ReplicatingDataInterface {
@@ -209,5 +212,16 @@ extension DataManager {
     
     var acceptLargeImagesPublisher: AnyPublisher<Bool, Never> {
         localStore.acceptLargeImagesPublisher
+    }
+}
+
+extension DataManager {
+    var basicChat: Bool {
+        get { localStore.basicChat }
+        set { localStore.basicChat = newValue }
+    }
+    
+    var basicChatPublisher: AnyPublisher<Bool, Never> {
+        get { localStore.basicChatPublisher }
     }
 }

--- a/iOS/DittoChat/Data/DittoService.swift
+++ b/iOS/DittoChat/Data/DittoService.swift
@@ -56,7 +56,6 @@ class DittoService: ReplicatingDataInterface {
 
     private let ditto = DittoInstance.shared.ditto
     private var privateStore: LocalDataInterface
-    private let PUBLIC_MESSAGES_ID = "1440174b9330e430b46da939f0b04a34a40e10ac8073671156da174fef1ffaef"
     
     private var joinRoomQuery: DittoSwift.DittoLiveQuery?
     
@@ -238,7 +237,7 @@ extension DittoService {
             .sort(createdOnKey, direction: .ascending)
             .liveQueryPublisher()
             .map { docs, _ in
-                docs.map { Message(document: $0) }
+                docs.map { Message(document: $0) }                
             }
             .eraseToAnyPublisher()        
     }
@@ -515,6 +514,7 @@ extension DittoService {
     private func createDefaultPublicRoom() {
         // Only create default Public room if user does not yet exist, i.e. first launch
         if privateStore.currentUserId != nil {
+//        if allPublicRooms.count > 0 {
             return
         }
         
@@ -524,7 +524,7 @@ extension DittoService {
                 dbIdKey: publicKey,
                 nameKey: publicRoomTitleKey,
                 collectionIdKey: publicRoomsCollectionId,
-                messagesIdKey: PUBLIC_MESSAGES_ID,
+                messagesIdKey: publicMessagesIdKey,//PUBLIC_MESSAGES_ID,
                 createdOnKey: DateFormatter.isoDate.string(from: Date()),
                 isPrivateKey: false
             ] as [String: Any?] )

--- a/iOS/DittoChat/Data/LocalStoreService.swift
+++ b/iOS/DittoChat/Data/LocalStoreService.swift
@@ -14,7 +14,7 @@ class LocalStoreService: LocalDataInterface {
     private let privateRoomsSubject: CurrentValueSubject<[Room], Never>
     private let archivedPrivateRoomsSubject: CurrentValueSubject<[Room], Never>
     private let archivedPublicRoomsSubject: CurrentValueSubject<[Room], Never>
-    
+        
     init() {
         let tmpDefaults = UserDefaults.standard
         
@@ -29,6 +29,17 @@ class LocalStoreService: LocalDataInterface {
         // prime archivedPublicRoomsSubject with decoded Room instances
         rooms = tmpDefaults.decodeRoomsFromData(Array(tmpDefaults.archivedPublicRooms.values))
         self.archivedPublicRoomsSubject = CurrentValueSubject<[Room], Never>(rooms)
+        
+        self.basicChat = UserDefaults.standard.basicChat        
+    }
+    
+    var basicChat: Bool {
+        get { defaults.basicChat }
+        set { defaults.basicChat = newValue }
+    }
+    
+    var basicChatPublisher: AnyPublisher<Bool, Never> {
+        defaults.basicChatPublisher
     }
     
     var acceptLargeImages: Bool {
@@ -239,6 +250,24 @@ fileprivate extension UserDefaults {
     var acceptLargeImagesPublisher: AnyPublisher<Bool, Never> {
         UserDefaults.standard
             .publisher(for: \.acceptLargeImages)
+            .eraseToAnyPublisher()
+    }
+}
+
+fileprivate extension UserDefaults {
+    
+    @objc var basicChat: Bool {
+        get {
+            object(forKey: basicChatKey) as? Bool ?? true
+        }
+        set(value) {
+            set(value, forKey: basicChatKey)
+        }
+    }
+    
+    var basicChatPublisher: AnyPublisher<Bool, Never> {
+        UserDefaults.standard
+            .publisher(for: \.basicChat)
             .eraseToAnyPublisher()
     }
 }

--- a/iOS/DittoChat/DittoChatApp.swift
+++ b/iOS/DittoChat/DittoChatApp.swift
@@ -5,15 +5,31 @@
 //  Created by Eric Turner on 12/6/22.
 //
 
+import Combine
 import SwiftUI
+
+class DittoChatAppVM: ObservableObject {
+    @Published var basicChatAsRootView = DataManager.shared.basicChat
+    
+    init() {
+        DataManager.shared.basicChatPublisher
+            .assign(to: &$basicChatAsRootView)
+    }
+}
 
 @main
 struct DittoChatApp: App {
+    @StateObject var vm = DittoChatAppVM()
     
     var body: some Scene {
         WindowGroup {
             NavigationStack {
-                RoomsListScreen()
+                if vm.basicChatAsRootView {
+                    ChatScreen(room: Room.basicChatDummy)
+                        .withErrorHandling()
+                } else {
+                    RoomsListScreen()
+                }
             }
         }
     }

--- a/iOS/DittoChat/Models/Room.swift
+++ b/iOS/DittoChat/Models/Room.swift
@@ -68,3 +68,16 @@ extension Room {
     }
 }
 
+extension Room {
+    // This "dummy" object is a Room object used by DittoChatApp.swift
+    // to initialize a basic chat mode ChatScreen as root view
+    static var basicChatDummy: Room {
+        Room(
+            id: publicKey,
+            name: publicRoomTitleKey,
+            messagesId: publicMessagesIdKey,
+            isPrivate: false
+        )
+    }
+}
+

--- a/iOS/DittoChat/Screens/ChatScreen/ChatScreen.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/ChatScreen.swift
@@ -18,6 +18,14 @@ struct ChatScreen: View {
         self._viewModel = StateObject(wrappedValue: ChatScreenVM(room: room))
     }
 
+    var navBarTitle: String {
+        if viewModel.isBasicChatScreen {
+            return appTitleKey
+        } else {
+            return viewModel.roomName
+        }
+    }
+    
     var body: some View {
         VStack {
             ScrollViewReader { proxy in
@@ -62,7 +70,7 @@ struct ChatScreen: View {
             )
         }
         .listStyle(.inset)
-        .navigationTitle(viewModel.roomName)
+        .navigationTitle(navBarTitle)
         .navigationBarTitleDisplayMode(.inline)
         .fullScreenCover(
             isPresented: $viewModel.presentAttachmentView,
@@ -90,7 +98,28 @@ struct ChatScreen: View {
                 }
             }
         }
+        .sheet(isPresented: $viewModel.presentProfileScreen) {// basic chat mode
+            ProfileScreen()
+        }
+        .sheet(isPresented: $viewModel.presentSettingsView) {// basic chat mode
+            SettingsScreen()
+        }
         .toolbar {
+            // basic chat mode
+            if viewModel.isBasicChatScreen {
+                ToolbarItemGroup(placement: .navigationBarLeading ) {
+                Button {
+                    viewModel.presentProfileScreen = true
+                } label: {
+                    Image(systemName: personCircleKey)
+                }
+                    Button {
+                        viewModel.presentSettingsView = true
+                    } label: {
+                        Image(systemName: gearShapeKey)
+                    }
+                }
+            }
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 if viewModel.room.isPrivate {
                     Button {

--- a/iOS/DittoChat/Screens/ChatScreen/ChatScreenVM.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/ChatScreenVM.swift
@@ -18,18 +18,32 @@ class ChatScreenVM: ObservableObject {
     @Published var inputText: String = ""
     @Published var roomName: String = ""
     @Published var messagesWithUsers = [MessageWithUser]()
+    var room: Room
+    
     @Published var selectedItem: PhotosPickerItem?
     @Published var selectedImage: UIImage?
     @Published var presentAttachmentView = false
     var attachmentMessage: Message?
-    @Published var presentShareRoomScreen = false
+    
     @Published var presentEditingView = false
     @Published var isEditing = false
     @Published var keyboardStatus: KeyboardChangeEvent = .unchanged
-    let room: Room
     var editMsgId: String?
+        
+    @Published var presentShareRoomScreen = false
+    
+    // Basic chat mode
+    @Published var presentProfileScreen: Bool = false
+    @Published var presentSettingsView = false
+    var isBasicChatScreen: Bool {
+        DataManager.shared.basicChat && room.id == publicKey
+    }
 
     init(room: Room) {
+        // In Basic chat mode, display profile screen if user is nil (first launch)
+        if room.id == publicKey && DataManager.shared.basicChat {
+            self.presentProfileScreen = DataManager.shared.currentUserId == nil
+        }
         self.room = room
 
         let users = DataManager.shared.allUsersPublisher()
@@ -48,6 +62,7 @@ class ChatScreenVM: ObservableObject {
 
         DataManager.shared.roomPublisher(for: room)
             .map { room -> String in
+                if let room = room { self.room = room }
                 return room?.name ?? ""
             }
             .assign(to: &$roomName)

--- a/iOS/DittoChat/Screens/ProfileScreen/ProfileScreen.swift
+++ b/iOS/DittoChat/Screens/ProfileScreen/ProfileScreen.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ProfileScreen: View {
     @Environment(\.dismiss) private var dismiss
-    @ObservedObject var viewModel = ProfileScreenViewModel()
+    @StateObject var viewModel = ProfileScreenViewModel()
 
     var body: some View {
         NavigationView {

--- a/iOS/DittoChat/Screens/RoomsListScreen/RoomsListScreen.swift
+++ b/iOS/DittoChat/Screens/RoomsListScreen/RoomsListScreen.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct RoomsListScreen: View {
-    @ObservedObject var viewModel = RoomsListScreenVM()
+    @ObservedObject var viewModel = RoomsListScreenVM()    
 
     var body: some View {
         List {
@@ -24,7 +24,7 @@ struct RoomsListScreen: View {
                 ForEach(viewModel.publicRooms) { room in
                     NavigationLink(value: room) {
                         RoomsListRowItem(room: room)
-                    }                    
+                    }
                     .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                         Button(settingsHideTitleKey) {
                             viewModel.archiveRoom(room)
@@ -33,7 +33,7 @@ struct RoomsListScreen: View {
                     }
                 }
             }
-
+            
             Section( viewModel.privateRooms.count > 0 ? privateRoomsTitleKey : "" ) {
                 ForEach(viewModel.privateRooms) { room in
                     NavigationLink(value: room) {
@@ -48,6 +48,7 @@ struct RoomsListScreen: View {
                 }
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(for: Room.self) { room in
             ChatScreen(room: room)
                 .withErrorHandling()

--- a/iOS/DittoChat/Screens/RoomsListScreen/RoomsListScreenVM.swift
+++ b/iOS/DittoChat/Screens/RoomsListScreen/RoomsListScreenVM.swift
@@ -26,7 +26,6 @@ class RoomsListScreenVM: ObservableObject {
             .receive(on: DispatchQueue.main)
             .map {[weak self] rooms in
                 self?.defaultPublicRoom = rooms.first(where: { $0.id == publicKey })
-                
                 // remove default public room; it's presented by itself in 1st list section
                 return rooms.filter { $0.id != publicKey }
             }

--- a/iOS/DittoChat/Screens/SettingsScreen/SettingsScreen.swift
+++ b/iOS/DittoChat/Screens/SettingsScreen/SettingsScreen.swift
@@ -11,30 +11,36 @@ import SwiftUI
 struct SettingsScreen: View {
     @StateObject var viewModel: SettingsScreenVM
     @State var acceptLargeImages: Bool
+    @State var advancedFeaturesEnabled: Bool
     
     init() {
         self._viewModel = StateObject(wrappedValue: SettingsScreenVM())
         self.acceptLargeImages = DataManager.shared.acceptLargeImages
+        self.advancedFeaturesEnabled = !DataManager.shared.basicChat
     }
     
     var body: some View {
         NavigationView {
-
             List {
-                
                 Section(userSettingsTitleKey) {
                     VStack(alignment: .leading) {
+                        
+                        Toggle("Enable Advanced Features", isOn: $advancedFeaturesEnabled)
+                            .onChange(of: advancedFeaturesEnabled) { shouldEnable in
+                                viewModel.enableAdvancedFeatures(useAdvanced: shouldEnable)
+                            }
+
+                        Divider()
+                        
                         Toggle("Enable Large Images", isOn: $acceptLargeImages)
                             .onChange(of: acceptLargeImages) { accept in
                                 viewModel.setLargeImagesPrefs(accept)
                             }
-
                         Text("Large image sync should only be enabled if all peers are known to be using WiFi.")
                             .font(.subheadline)
                             .padding(.top, 8)
                     }
                 }
-                
                 // DittoSwiftTools
                 Section {
                     NavigationLink {

--- a/iOS/DittoChat/Screens/SettingsScreen/SettingsScreenVM.swift
+++ b/iOS/DittoChat/Screens/SettingsScreen/SettingsScreenVM.swift
@@ -86,7 +86,12 @@ class SettingsScreenVM: ObservableObject {
         let appInfo = DataManager.shared.appInfo
         return "\(appInfo)\nDitto SDK \(vSDK)"
     }
-    
+
+    // Set basicChat to inverse of useAdvanced arg
+    func enableAdvancedFeatures(useAdvanced: Bool) {
+        DataManager.shared.basicChat = !useAdvanced
+    }
+
     func setLargeImagesPrefs(_ accept: Bool) {
         DataManager.shared.acceptLargeImages = accept
     }

--- a/iOS/DittoChat/Utilities/StringKeys.swift
+++ b/iOS/DittoChat/Utilities/StringKeys.swift
@@ -124,6 +124,7 @@ let basicChatKey = "basicChat"
 
 // MARK: Image Keys
 let arrowUpKey = "arrow.up"
+let cameraFillKey = "camera.fill"
 let checkmarkKey = "checkmark"
 let xmarkCircleKey = "xmark.circle"
 let gearShapeKey = "gearshape"

--- a/iOS/DittoChat/Utilities/StringKeys.swift
+++ b/iOS/DittoChat/Utilities/StringKeys.swift
@@ -30,6 +30,7 @@ let messagesKey = "messages"
 let nameKey = "name"
 let privateRoomsKey = "privateRooms"
 let publicKey = "public"
+let publicMessagesIdKey = "1440174b9330e430b46da939f0b04a34a40e10ac8073671156da174fef1ffaef"
 let publicRoomsCollectionId = "rooms"
 let roomIdKey = "roomId"
 let textKey = "text"
@@ -119,7 +120,7 @@ let publicRoomsIDArchiveKey = "publicRoomsIDArchive"
 let archivedPrivateRoomsKey = "archivedPrivateRooms"
 let privateRoomsIDArchiveKey = "privateRoomsIDArchive"
 let acceptLargeImagesKey = "acceptLargeImages"
-
+let basicChatKey = "basicChat"
 
 // MARK: Image Keys
 let arrowUpKey = "arrow.up"


### PR DESCRIPTION
The Basic Chat feature allows demonstrating messaging features, including image attachments, editing, and deleting messages, while hiding the more advanced features such as private rooms, archiving rooms, etc. As of this commit, the basic mode is enabled by default.

- add enableAdvancedFeatures preference in Settings
- DittoChatApp entry point switches UI between basic and advanced modes
- add ChatScreen and ChatScreenVM conditional logic for working as root view and displaying Settings, Profile screen overlays