### PR TITLE
Prevent attempt to display large image from Android

### DIFF
--- a/iOS/DittoChat/Screens/ChatScreen/MessageBubbleView.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/MessageBubbleView.swift
@@ -252,6 +252,7 @@ struct MessageBubbleView: View {
     private func canDisplayLargeImage() -> Bool {
         guard !isEditing else { return false }
         guard isImageMessage else { return false }
+        guard let _ = message.largeImageToken else { return false }
         return isSelfUser || largeImageAvailable
     }
 


### PR DESCRIPTION
Android version does not implement Message.largeImageToken. This commit fixes unresponsive long-press for large image for images from Android by checking first for largeImageToken value.