### PR TITLE
ISSUE-79 Resolves Ditto Identity based on the build type.

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -19,8 +19,15 @@ Android version of the Chat App Demo
 You need to setup some environment variables in order to build this project:
 
 1. In your project root, create a directory called **secure**
-2. Add two files to that directory called **debug_creds.properties** and **release_creds.properties**, for the debug and release build variants as defined in the app **build.gradle** file.
-2. Add the following environment variables to each credential file, substituting your own values:
+2. Create a file in that directory called **debug_creds.properties**.
+Add the following environment variables, substituting your own values:
+```
+    # Environment Variables  
+    DITTO_APP_ID = "replace with your app id"  
+    DITTO_PLAYGROUND_TOKEN = "replace with your online playground token"  
+```
+3. Create a file in that directory called **release_creds.properties**.
+Add the following environment variables, substituting your own values:
 ```
     # Environment Variables  
     DITTO_APP_ID = "replace with your app id"  
@@ -28,6 +35,7 @@ You need to setup some environment variables in order to build this project:
 ```
 
 * `DITTO_APP_ID` is the App ID used by Ditto; this needs to be the same on each device running the app in order for them to see each other, including across different platforms.
+* `DITTO_PLAYGROUND_TOKEN` is the online playground token.
 * `DITTO_LICENSE_TOKEN` is the offline-only playground token. Note this feature will be discontinued in the future.
 
  ## Copyright

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -29,7 +29,7 @@ android {
             def prop = new Properties()
             prop.load(new FileInputStream(credsFile))
             buildConfigField('String', 'DITTO_APP_ID', prop['DITTO_APP_ID']) // always use single quotes here
-            buildConfigField('String', 'DITTO_LICENSE_TOKEN', prop['DITTO_LICENSE_TOKEN'])
+            buildConfigField('String', 'DITTO_TOKEN', prop['DITTO_PLAYGROUND_TOKEN'])
         }
         release {
             minifyEnabled false
@@ -38,7 +38,7 @@ android {
             def prop = new Properties()
             prop.load(new FileInputStream(credsFile))
             buildConfigField('String', 'DITTO_APP_ID', prop['DITTO_APP_ID']) // always use single quotes here
-            buildConfigField('String', 'DITTO_LICENSE_TOKEN', prop['DITTO_LICENSE_TOKEN'])
+            buildConfigField('String', 'DITTO_TOKEN', prop['DITTO_LICENSE_TOKEN'])
         }
     }
     compileOptions {

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -21,24 +21,19 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        def credsFile = rootProject.file("secure\\creds.properties")
+        def prop = new Properties()
+        prop.load(new FileInputStream(credsFile))
+        buildConfigField('String', 'DITTO_APP_ID', prop['DITTO_APP_ID'])
+        buildConfigField('String', 'DITTO_PLAYGROUND_TOKEN', prop['DITTO_PLAYGROUND_TOKEN'])
+        buildConfigField('String', 'DITTO_OFFLINE_TOKEN', prop['DITTO_OFFLINE_TOKEN'])
     }
 
     buildTypes {
-        debug{
-            def credsFile = rootProject.file("secure\\creds.properties")
-            def prop = new Properties()
-            prop.load(new FileInputStream(credsFile))
-            buildConfigField('String', 'DITTO_APP_ID', prop['DITTO_APP_ID']) // always use single quotes here
-            buildConfigField('String', 'DITTO_PLAYGROUND_TOKEN', prop['DITTO_PLAYGROUND_TOKEN'])
-        }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            def credsFile = rootProject.file("secure\\creds.properties")
-            def prop = new Properties()
-            prop.load(new FileInputStream(credsFile))
-            buildConfigField('String', 'DITTO_APP_ID', prop['DITTO_APP_ID']) // always use single quotes here
-            buildConfigField('String', 'DITTO_OFFLINE_TOKEN', prop['DITTO_OFFLINE_TOKEN'])
         }
     }
     compileOptions {

--- a/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
@@ -48,15 +48,39 @@ class SplashActivity : AppCompatActivity() {
   }
 
   private fun setupDitto() {
-    val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
     DittoLogger.minimumLogLevel = DittoLogLevel.DEBUG
+
+    val androidDependencies = DefaultAndroidDittoDependencies(applicationContext)
     ditto = Ditto(
-      androidDependencies,
-      DittoIdentity.OfflinePlayground(androidDependencies, BuildConfig.DITTO_APP_ID)
+      dependencies = androidDependencies,
+      identity = resolveIdentity(androidDependencies)
     )
-    ditto.setOfflineOnlyLicenseToken(BuildConfig.DITTO_LICENSE_TOKEN)
+    ditto.setOfflineOnlyLicenseToken()
     // Disable sync with V3
-        ditto.disableSyncWithV3()
+    ditto.disableSyncWithV3()
     ditto.startSync()
+  }
+
+  /**
+   * Returns [DittoIdentity.OnlinePlayground] for Debug builds,
+   * [DittoIdentity.OfflinePlayground] otherwise.
+   */
+  private fun resolveIdentity(androidDependencies: DefaultAndroidDittoDependencies): DittoIdentity {
+    if (BuildConfig.DEBUG) return DittoIdentity.OnlinePlayground(
+      dependencies = androidDependencies,
+      appId = BuildConfig.DITTO_APP_ID,
+      token = BuildConfig.DITTO_LICENSE_TOKEN
+    )
+
+    return DittoIdentity.OfflinePlayground(androidDependencies, BuildConfig.DITTO_APP_ID)
+  }
+
+  /**
+   * Sets license token only on release build.
+   */
+  private fun Ditto.setOfflineOnlyLicenseToken() {
+    if (BuildConfig.DEBUG) return
+
+    setOfflineOnlyLicenseToken(BuildConfig.DITTO_LICENSE_TOKEN)
   }
 }

--- a/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt
@@ -69,7 +69,7 @@ class SplashActivity : AppCompatActivity() {
     if (BuildConfig.DEBUG) return DittoIdentity.OnlinePlayground(
       dependencies = androidDependencies,
       appId = BuildConfig.DITTO_APP_ID,
-      token = BuildConfig.DITTO_LICENSE_TOKEN
+      token = BuildConfig.DITTO_TOKEN
     )
 
     return DittoIdentity.OfflinePlayground(androidDependencies, BuildConfig.DITTO_APP_ID)
@@ -81,6 +81,6 @@ class SplashActivity : AppCompatActivity() {
   private fun Ditto.setOfflineOnlyLicenseToken() {
     if (BuildConfig.DEBUG) return
 
-    setOfflineOnlyLicenseToken(BuildConfig.DITTO_LICENSE_TOKEN)
+    setOfflineOnlyLicenseToken(BuildConfig.DITTO_TOKEN)
   }
 }


### PR DESCRIPTION
Fixes #79 

The problem
-
The setup process [configures Ditto](https://github.com/getditto/demoapp-chat/blob/52e473bf7d3d02ef87000998bed2bd78a3dd7a92/Android/app/src/main/java/live/dittolive/chat/SplashActivity.kt#L55) with `DittoIdentity.OfflinePlayground` which **does not allow** developers to use the Online Playground.

The solution:
-
Resolves the Ditto Identity based on the build type.
