### PR TITLE
Update ditto version

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-code-scanner:16.0.0")
 
     // Ditto
-    implementation("live.ditto:ditto:4.4.4")
+    implementation("live.ditto:ditto:4.5.4")
 //    implementation project(":dittoinfomodule")
 
     // Load Presence Viewer from an .aar library file

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "cc825b447b6292cc0a4a2f7e25d4fae0e3bfb1a8",
-        "version" : "4.4.4"
+        "revision" : "b7ff3bb584798818f56d1488a9176801cfbe6ce9",
+        "version" : "4.5.4"
       }
     },
     {


### PR DESCRIPTION
Update to v4.5, then will push update to app store. This will be a transition period for users to update to v4.5 so when we publish the DQL version it will reduce the risk of breaking.