### PR TITLE
Fix Xcode build phase that generates Env.swift

### DIFF
--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -557,12 +557,13 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/buildEnv.sh",
+				"${SRCROOT}/.env",
 			);
 			name = "Generate Env.swift";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Env.swift",
+				"${SRCROOT}/${PROJECT}/Env.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
I think recent Xcode version must change how the Xcode ENV vars resolve. The Env.swift file wasn't generating for me before, and with this fix, it generates as expected.

To test, remove the Env.swift from the project source in Finder (don't remove from the Navigator pane in Xcode), then Clean/Build as before.