### PR TITLE
Tweaks the format and README for the iOS Chat app to help users avoid a pitfall

### DIFF
--- a/iOS/README.md
+++ b/iOS/README.md
@@ -10,11 +10,13 @@ settings to your Apple developer account credentials to provision building to yo
 
 5. Edit `.env` to add environment variables as in the following example, substituting your own values as needed (based on your app configuration in the portal you will only need a subset of these values):
 ```
-    DITTO_APP_ID = "replace with your app id"
-    DITTO_PLAYGROUND_TOKEN = "replace with your playground token if applicable"
-    DITTO_AUTH_PASSWORD = "replace with your auth password if applicable"
-    DITTO_AUTH_PROVIDER = "replace with your auth provider if applicable"
+    DITTO_APP_ID = <replace with your app id>
+    DITTO_PLAYGROUND_TOKEN = <replace with your playground token if applicable>
+    DITTO_AUTH_PASSWORD = <replace with your auth password if applicable>
+    DITTO_AUTH_PROVIDER = <replace with your auth provider if applicable>
 ```
+* Note the lack of quotes around the values above
+
 * `DITTO_APP_ID` is the App ID used by Ditto; this needs to be the same on each device running the app in order for them to see each other, including across different platforms.
 * `DITTO_PLAYGROUND_TOKEN` is the online playground token. This is used when using the online playground identity type.
 * `DITTO_AUTH_PROVIDER` is the authentication provider name. This is used when using the online with authentication identity type.


### PR DESCRIPTION
Updates the README file to help users avoid a pitfall - the shell script that creates `Env.swift` from `.env` adds `"` around the values, so if you include the `"` in `.env` (as the readme previously implied to do) it generates an invalid `Env.swift` file.