### PR TITLE
iOS: fix chat input text leading edge margin

### DIFF
--- a/iOS/DittoChat/Views/ChatInputView/ChatInputView.swift
+++ b/iOS/DittoChat/Views/ChatInputView/ChatInputView.swift
@@ -43,10 +43,9 @@ struct ChatInputView: View {
     }
 }
 
-#if DEBUG
 struct ChatInputView_Previews: PreviewProvider {
     static var previews: some View {
         ChatInputView(text: .constant("Hellosdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfasdfasdfsdfsdfsdfsdf")){}
+            .previewLayout(.sizeThatFits)
     }
 }
-#endif

--- a/iOS/DittoChat/Views/ChatInputView/ExpandingTextView.swift
+++ b/iOS/DittoChat/Views/ChatInputView/ExpandingTextView.swift
@@ -24,6 +24,7 @@ struct ExpandingTextView: View {
             view.font = UIFont.systemFont(ofSize: UIFont.labelFontSize)
             view.backgroundColor = .clear
             view.delegate = context.coordinator
+            view.textContainerInset = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 0.0)
             return view
         }
 
@@ -86,10 +87,10 @@ struct ExpandingTextView: View {
     }
 }
 
-#if DEBUG
+
 struct ExpandingTextView_Previews: PreviewProvider {
     static var previews: some View {
         ExpandingTextView(text: .constant("foo"))
+            .previewLayout(.sizeThatFits)
     }
 }
-#endif


### PR DESCRIPTION
When cursor positioned at start of chat input text, cursor was too far to leading edge.

- add small edge inset margin to chat input view, ExpandingTextView wrapper