### PR TITLE
iOS AppStore release 4.0.4

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-code-scanner:16.0.0")
 
     // Ditto
-    implementation("live.ditto:ditto:4.4.4")
+    implementation("live.ditto:ditto:4.5.4")
 //    implementation project(":dittoinfomodule")
 
     // Load Presence Viewer from an .aar library file

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -14,7 +14,7 @@ android {
         applicationId "live.dittolive.chat"
         minSdk 29
         targetSdk 33
-        versionCode 27
+        versionCode 28
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -14,7 +14,7 @@ android {
         applicationId "live.dittolive.chat"
         minSdk 29
         targetSdk 33
-        versionCode 28
+        versionCode 30
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/Android/app/release/output-metadata.json
+++ b/Android/app/release/output-metadata.json
@@ -11,7 +11,7 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 28,
+      "versionCode": 30,
       "versionName": "1.0",
       "outputFile": "app-release.apk"
     }

--- a/Android/app/release/output-metadata.json
+++ b/Android/app/release/output-metadata.json
@@ -11,7 +11,7 @@
       "type": "SINGLE",
       "filters": [],
       "attributes": [],
-      "versionCode": 27,
+      "versionCode": 28,
       "versionName": "1.0",
       "outputFile": "app-release.apk"
     }

--- a/Android/app/src/main/java/live/dittolive/chat/components/DittochatDrawer.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/components/DittochatDrawer.kt
@@ -139,15 +139,6 @@ fun DittochatDrawerContent(
                     .height(24.dp),
                 contentDescription = stringResource(id = R.string.info)
             )
-            Icon(
-                imageVector = Icons.Outlined.Message,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .clickable(onClick = { /* TODO */ })
-                    .padding(horizontal = 12.dp, vertical = 16.dp)
-                    .height(24.dp),
-                contentDescription = stringResource(id = R.string.info)
-            )
         }
         
         DividerItem()

--- a/Android/app/src/main/java/live/dittolive/chat/data/FakeData.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/FakeData.kt
@@ -51,7 +51,6 @@ val colleagueProfile = ProfileScreenState(
     status = "Away",
     displayName = "eric",
     position = "Senior iOS Dev at Ditto",
-    twitter = "twitter.com/EricTurner",
     timeZone = "12:25 AM local time (Eastern Daylight Time)",
     commonChannels = "2"
 )
@@ -72,7 +71,6 @@ val meProfile = ProfileScreenState(
     status = "Online",
     displayName = "flexronin",
     position = "Senior Customer Engineer at Ditto\nAuthor of Android App Distribution",
-    twitter = "twitter.com/flexronin",
     timeZone = "In your timezone",
     commonChannels = null
 )

--- a/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
@@ -166,15 +166,6 @@ fun EditUserInfoFields(userData: ProfileScreenState, containerHeight: Dp,  userV
 
         EditNameAndPosition(userData, userViewModel = userViewModel)
 
-//        EditProfileProperty(stringResource(R.string.display_name), userData.displayName)
-//
-//        EditProfileProperty(stringResource(R.string.status), userData.status)
-//
-//
-//        userData.timeZone?.let {
-//            EditProfileProperty(stringResource(R.string.timezone), userData.timeZone)
-//        }
-
         // Add a spacer that always shows part (320.dp) of the fields list regardless of the device,
         // in order to always leave some content at the top.
         Spacer(Modifier.height((containerHeight - 320.dp).coerceAtLeast(0.dp)))
@@ -191,12 +182,6 @@ private fun EditNameAndPosition(
             modifier = Modifier.baselineHeight(32.dp),
             userViewModel = userViewModel
         )
-//        Position(
-//            userData.position,
-//            modifier = Modifier
-//                .padding(bottom = 20.dp)
-//                .baselineHeight(24.dp)
-//        )
     }
 }
 
@@ -263,6 +248,7 @@ fun EditProfileProperty(label: String, value: String, isLink: Boolean = false) {
 //}
 //
 //@Preview(widthDp = 360, heightDp = 480)
+//@Preview(widthDp = 360, heightDp = 480)var id
 //@Composable
 //fun EditConvPreviewPortraitMeDefault() {
 //    DittochatTheme {

--- a/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/EditProfile.kt
@@ -170,7 +170,6 @@ fun EditUserInfoFields(userData: ProfileScreenState, containerHeight: Dp,  userV
 //
 //        EditProfileProperty(stringResource(R.string.status), userData.status)
 //
-//        EditProfileProperty(stringResource(R.string.twitter), userData.twitter, isLink = true)
 //
 //        userData.timeZone?.let {
 //            EditProfileProperty(stringResource(R.string.timezone), userData.timeZone)

--- a/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
@@ -280,13 +280,13 @@ fun ProfileFab(
     modifier: Modifier = Modifier,
     onFabClicked: () -> Unit = { }
 ) {
-    var id : Int = if (isEditMode) {
+    val id : Int = if (isEditMode) {
         R.string.save_profile
     } else {
         R.string.edit_profile
     }
 
-    var imageVector : ImageVector = if (isEditMode) {
+    val imageVector : ImageVector = if (isEditMode) {
         Icons.Outlined.Save
     } else {
         Icons.Outlined.Create

--- a/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/Profile.kt
@@ -161,8 +161,6 @@ fun UserInfoFields(userData: ProfileScreenState, containerHeight: Dp, userViewMo
 
         ProfileProperty(stringResource(R.string.status), userData.status)
 
-        ProfileProperty(stringResource(R.string.twitter), userData.twitter, isLink = true)
-
         userData.timeZone?.let {
             ProfileProperty(stringResource(R.string.timezone), userData.timeZone)
         }
@@ -285,13 +283,13 @@ fun ProfileFab(
     var id : Int = if (isEditMode) {
         R.string.save_profile
     } else {
-        if (userIsMe) R.string.edit_profile else R.string.message
+        R.string.edit_profile
     }
 
     var imageVector : ImageVector = if (isEditMode) {
         Icons.Outlined.Save
     } else {
-        if (userIsMe) Icons.Outlined.Create else Icons.Outlined.Chat
+        Icons.Outlined.Create
     }
 
     key(userIsMe) { // Prevent multiple invocations to execute during composition

--- a/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/ProfileFragment.kt
@@ -91,20 +91,6 @@ class ProfileFragment : Fragment() {
                     DittochatAppBar(
                         onNavIconPressed = { activityViewModel.openDrawer() },
                         title = { },
-                        actions = {
-                            // More icon
-                            Icon(
-                                imageVector = Icons.Outlined.MoreVert,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier
-                                    .clickable(onClick = {
-                                        functionalityNotAvailablePopupShown = true
-                                    })
-                                    .padding(horizontal = 12.dp, vertical = 16.dp)
-                                    .height(24.dp),
-                                contentDescription = stringResource(id = R.string.more_options)
-                            )
-                        }
                     )
                 }
             }

--- a/Android/app/src/main/java/live/dittolive/chat/profile/ProfileViewModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/profile/ProfileViewModel.kt
@@ -83,7 +83,6 @@ data class ProfileScreenState(
     val status: String,
     val displayName: String,
     val position: String,
-    val twitter: String = "",
     val timeZone: String?, // Null if me
     val commonChannels: String?, // Null if me
 

--- a/Android/app/src/main/res/values/strings.xml
+++ b/Android/app/src/main/res/values/strings.xml
@@ -55,7 +55,6 @@
     <string name="display_name">Display name</string>
     <string name="status">Status</string>
     <string name="timezone">Timezone</string>
-    <string name="twitter">Twitter</string>
     <string name="profile_error">There was an error loading the profile</string>
     <string name="message">Message</string>
     <string name="edit_profile">Edit Profile</string>

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -551,12 +551,13 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/buildEnv.sh",
+				"${SRCROOT}/.env",
 			);
 			name = "Generate Env.swift";
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Env.swift",
+				"${SRCROOT}/${PROJECT}/Env.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -788,7 +788,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.3;
+				MARKETING_VERSION = 4.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = live.ditto.Chat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -822,7 +822,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.3;
+				MARKETING_VERSION = 4.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = live.ditto.Chat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "cc825b447b6292cc0a4a2f7e25d4fae0e3bfb1a8",
-        "version" : "4.4.4"
+        "revision" : "b7ff3bb584798818f56d1488a9176801cfbe6ce9",
+        "version" : "4.5.4"
       }
     },
     {

--- a/iOS/DittoChat/Screens/ChatScreen/ChatScreen.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/ChatScreen.swift
@@ -64,14 +64,15 @@ struct ChatScreen: View {
                     }
                 }
             }
-            HStack(alignment: .top) {
+
+            HStack(alignment: .center, spacing: 0) {
                 photosPickerButtonView
-                    .padding(.top, 4)
                 
                 ChatInputView(
                     text: $viewModel.inputText,
                     onSendButtonTappedCallback: viewModel.sendMessage
                 )
+                .padding(.leading, 0)
             }
         }
         .listStyle(.inset)
@@ -161,6 +162,9 @@ struct ChatScreen: View {
                 .font(.system(size: 28))
                 .foregroundColor(.accentColor)
         }
+        .padding(.leading, 12)
+        .padding(.trailing, 4)
+        .frame(width: 56, height: 44)
         .buttonStyle(.borderless)
         .onChange(of: viewModel.selectedItem) { newValue in
             Task {

--- a/iOS/DittoChat/Views/ChatInputView/ChatInputView.swift
+++ b/iOS/DittoChat/Views/ChatInputView/ChatInputView.swift
@@ -13,28 +13,31 @@ struct ChatInputView: View {
     var onSendButtonTappedCallback: (() -> Void)? = nil
 
     var body: some View {
-        HStack(alignment: .bottom) {
-            Spacer(minLength: 12)
-            HStack(alignment: .bottom) {
+
+        HStack(alignment: .center) {
+            
+            HStack(alignment: .center) {
+                
                 ExpandingTextView(text: $text)
-                    .padding(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
+                
                 Button {
                     onSendButtonTappedCallback?()
                 } label: {
                     Image(systemName: arrowUpKey)
-                        .padding(.all, 4)
+                        .padding(.all, 5)
                         .foregroundColor(Color.white)
                         .background(.blue)
                         .clipShape(Circle())
                 }
-                .padding(.bottom, 6)
+                .padding(4)
+                
                 Spacer(minLength: 8)
             }
             .overlay(
                 RoundedRectangle(cornerRadius: 20)
                     .stroke(.secondary, lineWidth: 1)
             )
-            .padding(.bottom, 12)
+            
             Spacer(minLength: 12)
         }
     }

--- a/iOS/DittoChat/Views/ChatInputView/ChatInputView.swift
+++ b/iOS/DittoChat/Views/ChatInputView/ChatInputView.swift
@@ -43,10 +43,9 @@ struct ChatInputView: View {
     }
 }
 
-#if DEBUG
 struct ChatInputView_Previews: PreviewProvider {
     static var previews: some View {
         ChatInputView(text: .constant("Hellosdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfasdfasdfsdfsdfsdfsdf")){}
+            .previewLayout(.sizeThatFits)
     }
 }
-#endif

--- a/iOS/DittoChat/Views/ChatInputView/ExpandingTextView.swift
+++ b/iOS/DittoChat/Views/ChatInputView/ExpandingTextView.swift
@@ -24,6 +24,7 @@ struct ExpandingTextView: View {
             view.font = UIFont.systemFont(ofSize: UIFont.labelFontSize)
             view.backgroundColor = .clear
             view.delegate = context.coordinator
+            view.textContainerInset = UIEdgeInsets(top: 8.0, left: 8.0, bottom: 8.0, right: 0.0)
             return view
         }
 
@@ -86,10 +87,10 @@ struct ExpandingTextView: View {
     }
 }
 
-#if DEBUG
+
 struct ExpandingTextView_Previews: PreviewProvider {
     static var previews: some View {
         ExpandingTextView(text: .constant("foo"))
+            .previewLayout(.sizeThatFits)
     }
 }
-#endif


### PR DESCRIPTION
DO NOT MERGE TO MAIN

UI updates for AppStore release: positioning of the camera button in the chat thread view to conform with Apple's HIG.

This is a special release to get UI updates into the AppStore before merging the DQL migration release, which will be a breaking change. 

This release branch is cut from `legacy-builder-api` branch for backward compatibility with the previous AppStore release which was cut from `legacy-builder-api`, which was created to preserve a legacy builder version of the codebase after the DQL migration was merged to `main`.  

The UI update commits were merged to `main` with the DQL migration branch still independent, but then it was noticed that `main` and `legacy-builder-api` had diverged, and the 4.0.3 AppStore release was no longer compatible with main. So the UI update commits were cherry-picked from `main` to `legacy-builder-api` and this release cut from that.

From here, the `legacy-builder-api` branch should be merged to `DQL` branch and thoroughly tested along with the Android version in this same repo. Only after QA is satisfied on and between both platform versions should `DQL` be merged to `main`. From main then can be cut v5.0.0, a major, backwards-incompatible, release.
