### PR TITLE
📎 Update attachments APIs

### DIFF
--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -983,7 +983,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.7.0;
 			};
 		};
 		14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */ = {

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "ce9a358ed7dc7dbb0b047bc9b8fb5a0d0c43a0f7dc85b9d00019e04838da56be",
   "pins" : [
     {
       "identity" : "codescanner",
@@ -14,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "d759e27d619c2035d070e033da7f84b71614e252",
-        "version" : "4.5.0"
+        "revision" : "808b636b11ddd129b956cc8d9c71534880a8a1f1",
+        "version" : "4.7.0"
       }
     },
     {
@@ -46,5 +47,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/iOS/DittoChat/Data/DataManager.swift
+++ b/iOS/DittoChat/Data/DataManager.swift
@@ -55,7 +55,7 @@ protocol ReplicatingDataInterface {
     func attachmentPublisher(
         for token: DittoAttachmentToken,
         in collectionId: String
-    ) -> DittoSwift.DittoCollection.FetchAttachmentPublisher
+    ) -> DittoSwift.DittoStore.FetchAttachmentPublisher
     
     func addUser(_ usr: User)
     func currentUserPublisher() -> AnyPublisher<User?, Never>
@@ -152,7 +152,7 @@ extension DataManager {
     func attachmentPublisher(
         for token: DittoAttachmentToken,
         in collectionId: String
-    ) -> DittoSwift.DittoCollection.FetchAttachmentPublisher {
+    ) -> DittoSwift.DittoStore.FetchAttachmentPublisher {
         p2pStore.attachmentPublisher(for: token, in: collectionId)
     }
 }

--- a/iOS/DittoChat/Data/DittoService.swift
+++ b/iOS/DittoChat/Data/DittoService.swift
@@ -412,7 +412,7 @@ extension DittoService {
             throw AttachmentError.tmpStorageWriteFail
         }
         
-        guard let thumbAttachment = await ditto.store[room.messagesId].newAttachment(
+        guard let thumbAttachment = try? await ditto.store.newAttachment(
             path: tmpStorage.fileURL.path,
             metadata: metadata(for: image, fname: fname, timestamp: nowDate)
         ) else {
@@ -459,7 +459,7 @@ extension DittoService {
             throw AttachmentError.tmpStorageWriteFail
         }
         
-        guard let largeAttachment = await ditto.store[room.messagesId].newAttachment(
+        guard let largeAttachment = try? await ditto.store.newAttachment(
             path: tmpStorage.fileURL.path,
             metadata: metadata(for: image, fname: fname, timestamp: nowDate)
         ) else {
@@ -554,8 +554,8 @@ extension DittoService {
     func attachmentPublisher(
         for token: DittoAttachmentToken,
         in collectionId: String
-    ) -> DittoSwift.DittoCollection.FetchAttachmentPublisher {
-        ditto.store[collectionId].fetchAttachmentPublisher(attachmentToken: token)
+    ) -> DittoSwift.DittoStore.FetchAttachmentPublisher {
+        ditto.store.fetchAttachmentPublisher(attachmentToken: token)
     }
 }
 

--- a/iOS/DittoChat/Data/DittoService.swift
+++ b/iOS/DittoChat/Data/DittoService.swift
@@ -785,7 +785,6 @@ extension DittoService {
     }
     
     func deletePrivateRoom(_ room: Room) {
-//        guard let collectionId = room.collectionId else {
         guard room.collectionId != nil else {
             print("\(#function): ERROR: Expected PrivateRoom collectionId not NIL")
             return

--- a/iOS/DittoChat/Data/DittoService.swift
+++ b/iOS/DittoChat/Data/DittoService.swift
@@ -785,7 +785,8 @@ extension DittoService {
     }
     
     func deletePrivateRoom(_ room: Room) {
-        guard let collectionId = room.collectionId else {
+//        guard let collectionId = room.collectionId else {
+        guard room.collectionId != nil else {
             print("\(#function): ERROR: Expected PrivateRoom collectionId not NIL")
             return
         }

--- a/iOS/DittoChat/Models/Message.swift
+++ b/iOS/DittoChat/Models/Message.swift
@@ -20,12 +20,22 @@ struct Message: Identifiable, Equatable {
     var roomId: String
     var text: String
     var userId: String
-    var largeImageToken: DittoAttachmentToken?
-    var thumbnailImageToken: DittoAttachmentToken?
-    
+    var largeImageToken: [String: Any]?
+    var thumbnailImageToken: [String: Any]?
+
     var isImageMessage: Bool {
         thumbnailImageToken != nil || largeImageToken != nil
-    }    
+    }
+
+    // FIXME: Excluding attachment tokens from equality because Any is not equatable
+    static func == (lhs: Message, rhs: Message) -> Bool {
+        return lhs.id == rhs.id &&
+        lhs.createdOn == rhs.createdOn &&
+        lhs.roomId == rhs.roomId &&
+        lhs.text == rhs.text &&
+        lhs.userId == rhs.userId &&
+        lhs.isImageMessage == rhs.isImageMessage
+    }
 }
 
 extension Message {
@@ -35,8 +45,8 @@ extension Message {
         roomId: String,
         text: String? = nil,
         userId: String? = nil,
-        largeImageToken: DittoAttachmentToken? = nil,
-        thumbnailImageToken: DittoAttachmentToken? = nil
+        largeImageToken: [String: Any]? = nil,
+        thumbnailImageToken: [String: Any]? = nil
     ) {
         self.id = id ?? UUID().uuidString
         self.createdOn = createdOn ?? Date()
@@ -96,9 +106,10 @@ extension Message: DittoDecodable {
             self.userId = DataManager.shared.currentUserId ?? createdByUnknownKey
         }
 
-        self.largeImageToken = value[largeImageTokenKey] as? DittoAttachmentToken
-        self.thumbnailImageToken = value[thumbnailImageTokenKey] as? DittoAttachmentToken
-        print("Checking thumbnailToken value \(String(describing: value[thumbnailImageTokenKey] as? DittoAttachmentToken))")
+        // Attachment tokens are now a sub-dictionary under the key the attachment was saved at.
+        self.largeImageToken = value[largeImageTokenKey] as? [String: Any]
+        self.thumbnailImageToken = value[thumbnailImageTokenKey] as? [String: Any]
+        print("Checking thumbnailToken value \(String(describing: value[thumbnailImageTokenKey] as? [String: Any]))")
 
     }
 }

--- a/iOS/DittoChat/Screens/ChatScreen/MessageBubbleVM.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/MessageBubbleVM.swift
@@ -110,7 +110,7 @@ struct ImageAttachmentFetcher {
     typealias ProgressHandler = (CompletionRatio) -> Void
     typealias CompletionHandler = (Result<ImageMetadataTuple, Error>) -> Void
 
-    func fetch(with token: DittoAttachmentToken?,
+    func fetch(with token: [String: Any]?,
                from collectionId: String,
                onProgress: @escaping ProgressHandler,
                onComplete: @escaping CompletionHandler

--- a/iOS/DittoChat/Screens/ChatScreen/MessageBubbleVM.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/MessageBubbleVM.swift
@@ -120,7 +120,7 @@ struct ImageAttachmentFetcher {
         // Fetch the thumbnail data from Ditto, calling the progress handler to
         // report the operation's ongoing progress.
         let ditto = DittoInstance.shared.ditto
-        let _ = ditto.store[collectionId].fetchAttachment(token: token) { event in
+        let _ = try? ditto.store.fetchAttachment(token: token) { event in
             switch event {
             case .progress(let downloadedBytes, let totalBytes):
                 let percent = Double(downloadedBytes) / Double(totalBytes)
@@ -128,7 +128,7 @@ struct ImageAttachmentFetcher {
 
             case .completed(let attachment):
                 do {
-                    let data = try attachment.getData()
+                    let data = try attachment.data()
                     if let uiImage = UIImage(data: data) {
                         onComplete(.success( (image: uiImage, metadata: attachment.metadata) ))
                     }


### PR DESCRIPTION
This PR is stacked on the `DQL` branch and targets PR #95.

I've updated DittoSwift to version `4.7.0` and migrated the attachments APIs to the newer `store.newAttachment()` and `store.fetchAttachment()` methods.

Note that I've excluded the `largeImageToken` and `thumbnailImageToken` properties of the `Message` struct from the equality check since I had to change their type to `[String: Any]`.