### PR TITLE
🥽 Add visionOS platform support

### DIFF
--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -988,7 +988,7 @@
 		};
 		14CADB59293FEFD700BED068 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
+			repositoryURL = "https://github.com/getditto/DittoSwiftPackage.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 4.7.0;
@@ -996,7 +996,7 @@
 		};
 		14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/vadymmarkov/Fakery";
+			repositoryURL = "https://github.com/vadymmarkov/Fakery.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 5.0.0;

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 60;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -68,6 +68,16 @@
 		F81907A92BC74D720003C117 /* DittoPermissionsHealth in Frameworks */ = {isa = PBXBuildFile; productRef = F81907A82BC74D720003C117 /* DittoPermissionsHealth */; };
 		F81907AB2BC74D720003C117 /* DittoPresenceDegradation in Frameworks */ = {isa = PBXBuildFile; productRef = F81907AA2BC74D720003C117 /* DittoPresenceDegradation */; };
 		F81907AD2BC74D720003C117 /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = F81907AC2BC74D720003C117 /* DittoPresenceViewer */; };
+		F889C4222BE19A4800EC6330 /* DittoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F889C4212BE19A4800EC6330 /* DittoSwift */; };
+		F889C4252BE19AD800EC6330 /* DittoDataBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = F889C4242BE19AD800EC6330 /* DittoDataBrowser */; };
+		F889C4272BE19AD800EC6330 /* DittoDiskUsage in Frameworks */ = {isa = PBXBuildFile; productRef = F889C4262BE19AD800EC6330 /* DittoDiskUsage */; };
+		F889C4292BE19AD800EC6330 /* DittoExportData in Frameworks */ = {isa = PBXBuildFile; productRef = F889C4282BE19AD800EC6330 /* DittoExportData */; };
+		F889C42B2BE19AD800EC6330 /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = F889C42A2BE19AD800EC6330 /* DittoExportLogs */; };
+		F889C42D2BE19AD800EC6330 /* DittoHeartbeat in Frameworks */ = {isa = PBXBuildFile; productRef = F889C42C2BE19AD800EC6330 /* DittoHeartbeat */; };
+		F889C42F2BE19AD800EC6330 /* DittoPeersList in Frameworks */ = {isa = PBXBuildFile; productRef = F889C42E2BE19AD800EC6330 /* DittoPeersList */; };
+		F889C4312BE19AD800EC6330 /* DittoPermissionsHealth in Frameworks */ = {isa = PBXBuildFile; productRef = F889C4302BE19AD800EC6330 /* DittoPermissionsHealth */; };
+		F889C4332BE19AD800EC6330 /* DittoPresenceDegradation in Frameworks */ = {isa = PBXBuildFile; productRef = F889C4322BE19AD800EC6330 /* DittoPresenceDegradation */; };
+		F889C4352BE19AD800EC6330 /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = F889C4342BE19AD800EC6330 /* DittoPresenceViewer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -150,17 +160,27 @@
 			buildActionMask = 2147483647;
 			files = (
 				14BF945D29786731001F672D /* CodeScanner in Frameworks */,
+				F889C42B2BE19AD800EC6330 /* DittoExportLogs in Frameworks */,
+				F889C42D2BE19AD800EC6330 /* DittoHeartbeat in Frameworks */,
 				F81907A32BC74D720003C117 /* DittoExportLogs in Frameworks */,
+				F889C4312BE19AD800EC6330 /* DittoPermissionsHealth in Frameworks */,
+				F889C4222BE19A4800EC6330 /* DittoSwift in Frameworks */,
 				F81907A52BC74D720003C117 /* DittoHeartbeat in Frameworks */,
 				F81907A12BC74D720003C117 /* DittoExportData in Frameworks */,
 				F81907A92BC74D720003C117 /* DittoPermissionsHealth in Frameworks */,
+				F889C4252BE19AD800EC6330 /* DittoDataBrowser in Frameworks */,
+				F889C4332BE19AD800EC6330 /* DittoPresenceDegradation in Frameworks */,
+				F889C42F2BE19AD800EC6330 /* DittoPeersList in Frameworks */,
 				F81907AB2BC74D720003C117 /* DittoPresenceDegradation in Frameworks */,
 				14CADB60293FF00700BED068 /* Fakery in Frameworks */,
+				F889C4272BE19AD800EC6330 /* DittoDiskUsage in Frameworks */,
 				F819079D2BC74D720003C117 /* DittoDataBrowser in Frameworks */,
 				F819079A2BC74C3D0003C117 /* DittoSwift in Frameworks */,
 				F819079F2BC74D720003C117 /* DittoDiskUsage in Frameworks */,
+				F889C4352BE19AD800EC6330 /* DittoPresenceViewer in Frameworks */,
 				F81907AD2BC74D720003C117 /* DittoPresenceViewer in Frameworks */,
 				F81907A72BC74D720003C117 /* DittoPeersList in Frameworks */,
+				F889C4292BE19AD800EC6330 /* DittoExportData in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -439,6 +459,16 @@
 				F81907A82BC74D720003C117 /* DittoPermissionsHealth */,
 				F81907AA2BC74D720003C117 /* DittoPresenceDegradation */,
 				F81907AC2BC74D720003C117 /* DittoPresenceViewer */,
+				F889C4212BE19A4800EC6330 /* DittoSwift */,
+				F889C4242BE19AD800EC6330 /* DittoDataBrowser */,
+				F889C4262BE19AD800EC6330 /* DittoDiskUsage */,
+				F889C4282BE19AD800EC6330 /* DittoExportData */,
+				F889C42A2BE19AD800EC6330 /* DittoExportLogs */,
+				F889C42C2BE19AD800EC6330 /* DittoHeartbeat */,
+				F889C42E2BE19AD800EC6330 /* DittoPeersList */,
+				F889C4302BE19AD800EC6330 /* DittoPermissionsHealth */,
+				F889C4322BE19AD800EC6330 /* DittoPresenceDegradation */,
+				F889C4342BE19AD800EC6330 /* DittoPresenceViewer */,
 			);
 			productName = DittoChat;
 			productReference = 14CADB2A293FEBD500BED068 /* DittoChat.app */;
@@ -516,8 +546,8 @@
 			packageReferences = (
 				14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */,
 				14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */,
-				F81907982BC74C3D0003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftPackage" */,
-				F819079B2BC74D720003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftTools" */,
+				F889C4202BE19A4800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */,
+				F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */,
 			);
 			productRefGroup = 14CADB2B293FEBD500BED068 /* Products */;
 			projectDirPath = "";
@@ -975,17 +1005,6 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCLocalSwiftPackageReference section */
-		F81907982BC74C3D0003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftPackage" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../DittoSwiftPackage;
-		};
-		F819079B2BC74D720003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftTools" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = ../../DittoSwiftTools;
-		};
-/* End XCLocalSwiftPackageReference section */
-
 /* Begin XCRemoteSwiftPackageReference section */
 		14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -1001,6 +1020,22 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 5.0.0;
+			};
+		};
+		F889C4202BE19A4800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getditto/DittoSwiftPackage.git";
+			requirement = {
+				kind = exactVersion;
+				version = "4.8.0-experimental-visionos-support";
+			};
+		};
+		F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getditto/DittoSwiftTools.git";
+			requirement = {
+				kind = exactVersion;
+				version = "4.8.0-experimental-visionos-support";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1054,6 +1089,56 @@
 		};
 		F81907AC2BC74D720003C117 /* DittoPresenceViewer */ = {
 			isa = XCSwiftPackageProductDependency;
+			productName = DittoPresenceViewer;
+		};
+		F889C4212BE19A4800EC6330 /* DittoSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4202BE19A4800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;
+			productName = DittoSwift;
+		};
+		F889C4242BE19AD800EC6330 /* DittoDataBrowser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoDataBrowser;
+		};
+		F889C4262BE19AD800EC6330 /* DittoDiskUsage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoDiskUsage;
+		};
+		F889C4282BE19AD800EC6330 /* DittoExportData */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoExportData;
+		};
+		F889C42A2BE19AD800EC6330 /* DittoExportLogs */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoExportLogs;
+		};
+		F889C42C2BE19AD800EC6330 /* DittoHeartbeat */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoHeartbeat;
+		};
+		F889C42E2BE19AD800EC6330 /* DittoPeersList */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoPeersList;
+		};
+		F889C4302BE19AD800EC6330 /* DittoPermissionsHealth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoPermissionsHealth;
+		};
+		F889C4322BE19AD800EC6330 /* DittoPresenceDegradation */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
+			productName = DittoPresenceDegradation;
+		};
+		F889C4342BE19AD800EC6330 /* DittoPresenceViewer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
 			productName = DittoPresenceViewer;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -48,8 +48,6 @@
 		14CADB49293FEBD600BED068 /* DittoChatUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CADB48293FEBD600BED068 /* DittoChatUITests.swift */; };
 		14CADB4B293FEBD600BED068 /* DittoChatUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CADB4A293FEBD600BED068 /* DittoChatUITestsLaunchTests.swift */; };
 		14CADB58293FEC1400BED068 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14CADB57293FEC1400BED068 /* Assets.xcassets */; };
-		14CADB5B293FEFD700BED068 /* DittoObjC in Frameworks */ = {isa = PBXBuildFile; productRef = 14CADB5A293FEFD700BED068 /* DittoObjC */; };
-		14CADB5D293FEFD700BED068 /* DittoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 14CADB5C293FEFD700BED068 /* DittoSwift */; };
 		14CADB60293FF00700BED068 /* Fakery in Frameworks */ = {isa = PBXBuildFile; productRef = 14CADB5F293FF00700BED068 /* Fakery */; };
 		14D902E92954DFC8006B54E3 /* StringKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D902E82954DFC8006B54E3 /* StringKeys.swift */; };
 		14D902EB2954ED1B006B54E3 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14D902EA2954ED1B006B54E3 /* Utils.swift */; };
@@ -66,6 +64,7 @@
 		14E834CC2953C7B20027D750 /* RoomEditScreenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E834CA2953C7B20027D750 /* RoomEditScreenViewModel.swift */; };
 		14E834CF2953C7B90027D750 /* RoomsListScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E834CD2953C7B90027D750 /* RoomsListScreen.swift */; };
 		14E834D02953C7B90027D750 /* RoomsListScreenVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E834CE2953C7B90027D750 /* RoomsListScreenVM.swift */; };
+		F819079A2BC74C3D0003C117 /* DittoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F81907992BC74C3D0003C117 /* DittoSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -150,11 +149,10 @@
 				14A2B746298987D300E0FF86 /* DittoDiskUsage in Frameworks */,
 				14A2B748298987D300E0FF86 /* DittoExportLogs in Frameworks */,
 				14BF945D29786731001F672D /* CodeScanner in Frameworks */,
-				14CADB5B293FEFD700BED068 /* DittoObjC in Frameworks */,
 				143FFCC42B20F4840085A2EF /* DittoExportData in Frameworks */,
-				14CADB5D293FEFD700BED068 /* DittoSwift in Frameworks */,
 				14CADB60293FF00700BED068 /* Fakery in Frameworks */,
 				14A2B74A298987D400E0FF86 /* DittoPresenceViewer in Frameworks */,
+				F819079A2BC74C3D0003C117 /* DittoSwift in Frameworks */,
 				14A2B744298987D300E0FF86 /* DittoDataBrowser in Frameworks */,
 				143FFCC62B20F4840085A2EF /* DittoPeersList in Frameworks */,
 			);
@@ -423,8 +421,6 @@
 			);
 			name = DittoChat;
 			packageProductDependencies = (
-				14CADB5A293FEFD700BED068 /* DittoObjC */,
-				14CADB5C293FEFD700BED068 /* DittoSwift */,
 				14CADB5F293FF00700BED068 /* Fakery */,
 				14BF945C29786731001F672D /* CodeScanner */,
 				14A2B743298987D300E0FF86 /* DittoDataBrowser */,
@@ -433,6 +429,7 @@
 				14A2B749298987D400E0FF86 /* DittoPresenceViewer */,
 				143FFCC32B20F4840085A2EF /* DittoExportData */,
 				143FFCC52B20F4840085A2EF /* DittoPeersList */,
+				F81907992BC74C3D0003C117 /* DittoSwift */,
 			);
 			productName = DittoChat;
 			productReference = 14CADB2A293FEBD500BED068 /* DittoChat.app */;
@@ -508,10 +505,10 @@
 			);
 			mainGroup = 14CADB21293FEBD500BED068;
 			packageReferences = (
-				14CADB59293FEFD700BED068 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */,
 				14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */,
 				14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */,
 				14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */,
+				F81907982BC74C3D0003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftPackage" */,
 			);
 			productRefGroup = 14CADB2B293FEBD500BED068 /* Products */;
 			projectDirPath = "";
@@ -969,6 +966,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		F81907982BC74C3D0003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../DittoSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -984,14 +988,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 2.0.0;
-			};
-		};
-		14CADB59293FEFD700BED068 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getditto/DittoSwiftPackage.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.7.0;
 			};
 		};
 		14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */ = {
@@ -1040,20 +1036,14 @@
 			package = 14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */;
 			productName = CodeScanner;
 		};
-		14CADB5A293FEFD700BED068 /* DittoObjC */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14CADB59293FEFD700BED068 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;
-			productName = DittoObjC;
-		};
-		14CADB5C293FEFD700BED068 /* DittoSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14CADB59293FEFD700BED068 /* XCRemoteSwiftPackageReference "DittoSwiftPackage" */;
-			productName = DittoSwift;
-		};
 		14CADB5F293FF00700BED068 /* Fakery */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */;
 			productName = Fakery;
+		};
+		F81907992BC74C3D0003C117 /* DittoSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -804,9 +804,12 @@
 				MARKETING_VERSION = 4.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = live.ditto.Chat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -838,9 +841,12 @@
 				MARKETING_VERSION = 4.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = live.ditto.Chat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -85,21 +85,6 @@
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		F801B8D92BC710EC0063DCE6 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 12;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				F801B8DB2BC710EE0063DCE6 /* DittoSwift.xcframework in Embed Frameworks */,
-				F801B8D82BC710EC0063DCE6 /* DittoObjC.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		0ED7E4372B520DE5007C8E52 /* Publishers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publishers.swift; sourceTree = "<group>"; };
 		142B278D2A39290700C09751 /* Env.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Env.swift; sourceTree = "<group>"; };

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -85,6 +85,21 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		F801B8D92BC710EC0063DCE6 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 12;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F801B8DB2BC710EE0063DCE6 /* DittoSwift.xcframework in Embed Frameworks */,
+				F801B8D82BC710EC0063DCE6 /* DittoObjC.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		0ED7E4372B520DE5007C8E52 /* Publishers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publishers.swift; sourceTree = "<group>"; };
 		142B278D2A39290700C09751 /* Env.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Env.swift; sourceTree = "<group>"; };
@@ -786,6 +801,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"DittoChat/Preview Content\"";
 				DEVELOPMENT_TEAM = 3T2VMFZPPQ;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DittoChat/Info.plist;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Uses Bluetooth to connect and sync with nearby devices";
@@ -823,6 +839,7 @@
 				DEVELOPMENT_ASSET_PATHS = "\"DittoChat/Preview Content\"";
 				DEVELOPMENT_TEAM = 3T2VMFZPPQ;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DittoChat/Info.plist;
 				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "Uses Bluetooth to connect and sync with nearby devices";

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -1027,7 +1027,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage.git";
 			requirement = {
 				kind = exactVersion;
-				version = "4.8.0-experimental-visionos-support";
+				version = "4.8.0-visionos-beta.1";
 			};
 		};
 		F889C4232BE19AD800EC6330 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */ = {
@@ -1035,7 +1035,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftTools.git";
 			requirement = {
 				kind = exactVersion;
-				version = "4.8.0-experimental-visionos-support";
+				version = "4.8.0-visionos-beta.1";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		14B98AAD297C774F00509E57 /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B98AAC297C774F00509E57 /* SettingsScreen.swift */; };
 		14B98AAF297C7CB600509E57 /* RoomDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B98AAE297C7CB600509E57 /* RoomDetailsView.swift */; };
 		14BB526429A010790072C4AD /* RoomsListRowItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BB526329A010790072C4AD /* RoomsListRowItem.swift */; };
-		14BF945D29786731001F672D /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 14BF945C29786731001F672D /* CodeScanner */; };
+		14BF945D29786731001F672D /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = 14BF945C29786731001F672D /* CodeScanner */; };
 		14BF945F297868ED001F672D /* Room.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14BF945E297868ED001F672D /* Room.swift */; };
 		14CADB2E293FEBD500BED068 /* DittoChatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CADB2D293FEBD500BED068 /* DittoChatApp.swift */; };
 		14CADB35293FEBD600BED068 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 14CADB34293FEBD600BED068 /* Preview Assets.xcassets */; };

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -10,8 +10,6 @@
 		0ED7E4382B520DE5007C8E52 /* Publishers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED7E4372B520DE5007C8E52 /* Publishers.swift */; };
 		142B278E2A39290700C09751 /* Env.swift in Sources */ = {isa = PBXBuildFile; fileRef = 142B278D2A39290700C09751 /* Env.swift */; };
 		143FFCC02B20F39C0085A2EF /* DittoToolsListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143FFCBE2B20F39C0085A2EF /* DittoToolsListItem.swift */; };
-		143FFCC42B20F4840085A2EF /* DittoExportData in Frameworks */ = {isa = PBXBuildFile; productRef = 143FFCC32B20F4840085A2EF /* DittoExportData */; };
-		143FFCC62B20F4840085A2EF /* DittoPeersList in Frameworks */ = {isa = PBXBuildFile; productRef = 143FFCC52B20F4840085A2EF /* DittoPeersList */; };
 		1493FF6A2978763500397DAB /* ScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493FF682978763500397DAB /* ScannerView.swift */; };
 		1493FF6B2978763500397DAB /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493FF692978763500397DAB /* QRCodeView.swift */; };
 		14A0B87129D3BB5D00D2D625 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B86F29D3BB5D00D2D625 /* ErrorHandler.swift */; };
@@ -23,10 +21,6 @@
 		14A0B87E29D3BC4100D2D625 /* UIImage+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B87C29D3BC4100D2D625 /* UIImage+Rotation.swift */; };
 		14A0B88029D49E7200D2D625 /* GeneralErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B87F29D49E7200D2D625 /* GeneralErrorView.swift */; };
 		14A0B88329D60C6800D2D625 /* MessageEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A0B88229D60C6800D2D625 /* MessageEditView.swift */; };
-		14A2B744298987D300E0FF86 /* DittoDataBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = 14A2B743298987D300E0FF86 /* DittoDataBrowser */; };
-		14A2B746298987D300E0FF86 /* DittoDiskUsage in Frameworks */ = {isa = PBXBuildFile; productRef = 14A2B745298987D300E0FF86 /* DittoDiskUsage */; };
-		14A2B748298987D300E0FF86 /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = 14A2B747298987D300E0FF86 /* DittoExportLogs */; };
-		14A2B74A298987D400E0FF86 /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = 14A2B749298987D400E0FF86 /* DittoPresenceViewer */; };
 		14A2B74C29899ABF00E0FF86 /* DittoToolsUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A2B74B29899ABF00E0FF86 /* DittoToolsUtilities.swift */; };
 		14B4E2602978F2350069B69D /* ChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B4E25F2978F2350069B69D /* ChatInputView.swift */; };
 		14B4E2622978F23E0069B69D /* ExpandingTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B4E2612978F23E0069B69D /* ExpandingTextView.swift */; };
@@ -65,6 +59,15 @@
 		14E834CF2953C7B90027D750 /* RoomsListScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E834CD2953C7B90027D750 /* RoomsListScreen.swift */; };
 		14E834D02953C7B90027D750 /* RoomsListScreenVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E834CE2953C7B90027D750 /* RoomsListScreenVM.swift */; };
 		F819079A2BC74C3D0003C117 /* DittoSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F81907992BC74C3D0003C117 /* DittoSwift */; };
+		F819079D2BC74D720003C117 /* DittoDataBrowser in Frameworks */ = {isa = PBXBuildFile; productRef = F819079C2BC74D720003C117 /* DittoDataBrowser */; };
+		F819079F2BC74D720003C117 /* DittoDiskUsage in Frameworks */ = {isa = PBXBuildFile; productRef = F819079E2BC74D720003C117 /* DittoDiskUsage */; };
+		F81907A12BC74D720003C117 /* DittoExportData in Frameworks */ = {isa = PBXBuildFile; productRef = F81907A02BC74D720003C117 /* DittoExportData */; };
+		F81907A32BC74D720003C117 /* DittoExportLogs in Frameworks */ = {isa = PBXBuildFile; productRef = F81907A22BC74D720003C117 /* DittoExportLogs */; };
+		F81907A52BC74D720003C117 /* DittoHeartbeat in Frameworks */ = {isa = PBXBuildFile; productRef = F81907A42BC74D720003C117 /* DittoHeartbeat */; };
+		F81907A72BC74D720003C117 /* DittoPeersList in Frameworks */ = {isa = PBXBuildFile; productRef = F81907A62BC74D720003C117 /* DittoPeersList */; };
+		F81907A92BC74D720003C117 /* DittoPermissionsHealth in Frameworks */ = {isa = PBXBuildFile; productRef = F81907A82BC74D720003C117 /* DittoPermissionsHealth */; };
+		F81907AB2BC74D720003C117 /* DittoPresenceDegradation in Frameworks */ = {isa = PBXBuildFile; productRef = F81907AA2BC74D720003C117 /* DittoPresenceDegradation */; };
+		F81907AD2BC74D720003C117 /* DittoPresenceViewer in Frameworks */ = {isa = PBXBuildFile; productRef = F81907AC2BC74D720003C117 /* DittoPresenceViewer */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -146,15 +149,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				14A2B746298987D300E0FF86 /* DittoDiskUsage in Frameworks */,
-				14A2B748298987D300E0FF86 /* DittoExportLogs in Frameworks */,
 				14BF945D29786731001F672D /* CodeScanner in Frameworks */,
-				143FFCC42B20F4840085A2EF /* DittoExportData in Frameworks */,
+				F81907A32BC74D720003C117 /* DittoExportLogs in Frameworks */,
+				F81907A52BC74D720003C117 /* DittoHeartbeat in Frameworks */,
+				F81907A12BC74D720003C117 /* DittoExportData in Frameworks */,
+				F81907A92BC74D720003C117 /* DittoPermissionsHealth in Frameworks */,
+				F81907AB2BC74D720003C117 /* DittoPresenceDegradation in Frameworks */,
 				14CADB60293FF00700BED068 /* Fakery in Frameworks */,
-				14A2B74A298987D400E0FF86 /* DittoPresenceViewer in Frameworks */,
+				F819079D2BC74D720003C117 /* DittoDataBrowser in Frameworks */,
 				F819079A2BC74C3D0003C117 /* DittoSwift in Frameworks */,
-				14A2B744298987D300E0FF86 /* DittoDataBrowser in Frameworks */,
-				143FFCC62B20F4840085A2EF /* DittoPeersList in Frameworks */,
+				F819079F2BC74D720003C117 /* DittoDiskUsage in Frameworks */,
+				F81907AD2BC74D720003C117 /* DittoPresenceViewer in Frameworks */,
+				F81907A72BC74D720003C117 /* DittoPeersList in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -423,13 +429,16 @@
 			packageProductDependencies = (
 				14CADB5F293FF00700BED068 /* Fakery */,
 				14BF945C29786731001F672D /* CodeScanner */,
-				14A2B743298987D300E0FF86 /* DittoDataBrowser */,
-				14A2B745298987D300E0FF86 /* DittoDiskUsage */,
-				14A2B747298987D300E0FF86 /* DittoExportLogs */,
-				14A2B749298987D400E0FF86 /* DittoPresenceViewer */,
-				143FFCC32B20F4840085A2EF /* DittoExportData */,
-				143FFCC52B20F4840085A2EF /* DittoPeersList */,
 				F81907992BC74C3D0003C117 /* DittoSwift */,
+				F819079C2BC74D720003C117 /* DittoDataBrowser */,
+				F819079E2BC74D720003C117 /* DittoDiskUsage */,
+				F81907A02BC74D720003C117 /* DittoExportData */,
+				F81907A22BC74D720003C117 /* DittoExportLogs */,
+				F81907A42BC74D720003C117 /* DittoHeartbeat */,
+				F81907A62BC74D720003C117 /* DittoPeersList */,
+				F81907A82BC74D720003C117 /* DittoPermissionsHealth */,
+				F81907AA2BC74D720003C117 /* DittoPresenceDegradation */,
+				F81907AC2BC74D720003C117 /* DittoPresenceViewer */,
 			);
 			productName = DittoChat;
 			productReference = 14CADB2A293FEBD500BED068 /* DittoChat.app */;
@@ -507,8 +516,8 @@
 			packageReferences = (
 				14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */,
 				14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */,
-				14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */,
 				F81907982BC74C3D0003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftPackage" */,
+				F819079B2BC74D720003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftTools" */,
 			);
 			productRefGroup = 14CADB2B293FEBD500BED068 /* Products */;
 			projectDirPath = "";
@@ -971,17 +980,13 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../../DittoSwiftPackage;
 		};
+		F819079B2BC74D720003C117 /* XCLocalSwiftPackageReference "../../DittoSwiftTools" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../DittoSwiftTools;
+		};
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getditto/DittoSwiftTools.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.4.0;
-			};
-		};
 		14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/twostraws/CodeScanner.git";
@@ -1001,36 +1006,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		143FFCC32B20F4840085A2EF /* DittoExportData */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
-			productName = DittoExportData;
-		};
-		143FFCC52B20F4840085A2EF /* DittoPeersList */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
-			productName = DittoPeersList;
-		};
-		14A2B743298987D300E0FF86 /* DittoDataBrowser */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
-			productName = DittoDataBrowser;
-		};
-		14A2B745298987D300E0FF86 /* DittoDiskUsage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
-			productName = DittoDiskUsage;
-		};
-		14A2B747298987D300E0FF86 /* DittoExportLogs */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
-			productName = DittoExportLogs;
-		};
-		14A2B749298987D400E0FF86 /* DittoPresenceViewer */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 14A2B73F2989825000E0FF86 /* XCRemoteSwiftPackageReference "DittoSwiftTools" */;
-			productName = DittoPresenceViewer;
-		};
 		14BF945C29786731001F672D /* CodeScanner */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */;
@@ -1044,6 +1019,42 @@
 		F81907992BC74C3D0003C117 /* DittoSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = DittoSwift;
+		};
+		F819079C2BC74D720003C117 /* DittoDataBrowser */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoDataBrowser;
+		};
+		F819079E2BC74D720003C117 /* DittoDiskUsage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoDiskUsage;
+		};
+		F81907A02BC74D720003C117 /* DittoExportData */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoExportData;
+		};
+		F81907A22BC74D720003C117 /* DittoExportLogs */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoExportLogs;
+		};
+		F81907A42BC74D720003C117 /* DittoHeartbeat */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoHeartbeat;
+		};
+		F81907A62BC74D720003C117 /* DittoPeersList */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoPeersList;
+		};
+		F81907A82BC74D720003C117 /* DittoPermissionsHealth */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoPermissionsHealth;
+		};
+		F81907AA2BC74D720003C117 /* DittoPresenceDegradation */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoPresenceDegradation;
+		};
+		F81907AC2BC74D720003C117 /* DittoPresenceViewer */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DittoPresenceViewer;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fda8ebad4505a013a4ffcce2175da01db0b8ea667f7a7ee753397260947b0428",
+  "originHash" : "54a5037c9ce9e37ba3e66f462a05b6eff9902ce5cb2f68fa20147a678577e325",
   "pins" : [
     {
       "identity" : "codescanner",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "f4179cecc59e6cb58a044d89572f4b95146eb57c",
-        "version" : "4.8.0-experimental-visionos-support"
+        "revision" : "7964986665af7acd1065cf7c8fcab584ec580bbd",
+        "version" : "4.8.0-visionos-beta.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools.git",
       "state" : {
-        "revision" : "8f2a65cc7fcd7f98e05ca7bfdc31aa5b5011c038",
-        "version" : "4.8.0-experimental-visionos-support"
+        "revision" : "ad84a398fb5f8878066f3c556c12493d989b8949",
+        "version" : "4.8.0-visionos-beta.1"
       }
     },
     {

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "54a5037c9ce9e37ba3e66f462a05b6eff9902ce5cb2f68fa20147a678577e325",
+  "originHash" : "78796b399787728ef17ea568ecd0294e62243a046119ac694a32873499840226",
   "pins" : [
     {
       "identity" : "codescanner",

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,19 +1,19 @@
 {
-  "originHash" : "ce9a358ed7dc7dbb0b047bc9b8fb5a0d0c43a0f7dc85b9d00019e04838da56be",
+  "originHash" : "54a5037c9ce9e37ba3e66f462a05b6eff9902ce5cb2f68fa20147a678577e325",
   "pins" : [
     {
       "identity" : "codescanner",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/twostraws/CodeScanner.git",
       "state" : {
-        "revision" : "bf5d7087015620b250ee6c865b3c9039fc159d1a",
-        "version" : "2.3.3"
+        "revision" : "303bd5adbb61d068c3bcbb839857340c3e6ff8b0",
+        "version" : "2.4.0"
       }
     },
     {
       "identity" : "dittoswiftpackage",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getditto/DittoSwiftPackage",
+      "location" : "https://github.com/getditto/DittoSwiftPackage.git",
       "state" : {
         "revision" : "e9ac25ae9d38d215cc5958c995450dbc9b9dbea7",
         "version" : "4.7.1"
@@ -24,14 +24,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools.git",
       "state" : {
-        "revision" : "c121a51ce7dba950df94689e3f5a695342883fa0",
-        "version" : "4.4.0"
+        "revision" : "e78ed387c8467e60c7909b9af2ad5af5eabe076b",
+        "version" : "4.7.4"
       }
     },
     {
       "identity" : "fakery",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vadymmarkov/Fakery",
+      "location" : "https://github.com/vadymmarkov/Fakery.git",
       "state" : {
         "revision" : "71cb3bf36a808534659d1248780c2bf3c4c4fc91",
         "version" : "5.1.0"
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
-        "version" : "1.0.5"
+        "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
+        "version" : "1.1.0"
       }
     }
   ],

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "78796b399787728ef17ea568ecd0294e62243a046119ac694a32873499840226",
+  "originHash" : "b3b90a1b3d23af3336a717d166cbe5bde83f51ca9cb71a0ea99ccd79a7fc767c",
   "pins" : [
     {
       "identity" : "codescanner",
@@ -40,7 +40,7 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "git@github.com:apple/swift-collections.git",
       "state" : {
         "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
         "version" : "1.1.0"

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b3b90a1b3d23af3336a717d166cbe5bde83f51ca9cb71a0ea99ccd79a7fc767c",
+  "originHash" : "fda8ebad4505a013a4ffcce2175da01db0b8ea667f7a7ee753397260947b0428",
   "pins" : [
     {
       "identity" : "codescanner",
@@ -13,10 +13,10 @@
     {
       "identity" : "dittoswiftpackage",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/getditto/DittoSwiftPackage.git",
+      "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "e9ac25ae9d38d215cc5958c995450dbc9b9dbea7",
-        "version" : "4.7.1"
+        "revision" : "f4179cecc59e6cb58a044d89572f4b95146eb57c",
+        "version" : "4.8.0-experimental-visionos-support"
       }
     },
     {
@@ -24,14 +24,14 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftTools.git",
       "state" : {
-        "revision" : "e78ed387c8467e60c7909b9af2ad5af5eabe076b",
-        "version" : "4.7.4"
+        "revision" : "8f2a65cc7fcd7f98e05ca7bfdc31aa5b5011c038",
+        "version" : "4.8.0-experimental-visionos-support"
       }
     },
     {
       "identity" : "fakery",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/vadymmarkov/Fakery.git",
+      "location" : "https://github.com/vadymmarkov/Fakery",
       "state" : {
         "revision" : "71cb3bf36a808534659d1248780c2bf3c4c4fc91",
         "version" : "5.1.0"
@@ -40,7 +40,7 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "git@github.com:apple/swift-collections.git",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
         "revision" : "94cf62b3ba8d4bed62680a282d4c25f9c63c2efb",
         "version" : "1.1.0"

--- a/iOS/DittoChat.xcodeproj/xcshareddata/xcschemes/DittoChat.xcscheme
+++ b/iOS/DittoChat.xcodeproj/xcshareddata/xcschemes/DittoChat.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "14CADB29293FEBD500BED068"
+               BuildableName = "DittoChat.app"
+               BlueprintName = "DittoChat"
+               ReferencedContainer = "container:DittoChat.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "14CADB29293FEBD500BED068"
+            BuildableName = "DittoChat.app"
+            BlueprintName = "DittoChat"
+            ReferencedContainer = "container:DittoChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "14CADB29293FEBD500BED068"
+            BuildableName = "DittoChat.app"
+            BlueprintName = "DittoChat"
+            ReferencedContainer = "container:DittoChat.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/DittoChat/Data/DittoService.swift
+++ b/iOS/DittoChat/Data/DittoService.swift
@@ -91,9 +91,22 @@ extension DittoInstance {
         default:
             DittoLogger.enabled = true
             DittoLogger.minimumLogLevel = DittoLogLevel(rawValue: logOption.rawValue)!
-            if let logFileURL = DittoLogManager.shared.logFileURL {
-                DittoLogger.setLogFileURL(logFileURL)
+
+            let logsDirectoryName = "debug-logs"
+            let logFileName = "logs.txt"
+            
+            let logsDirectory = FileManager.default
+                .urls(for: .cachesDirectory, in: .userDomainMask).first!
+                .appendingPathComponent(logsDirectoryName, isDirectory: true)
+
+            do {
+                try FileManager.default.createDirectory(at: logsDirectory,
+                                                        withIntermediateDirectories: true)
+            } catch let error {
+                assertionFailure("Failed to create logs directory: \(error)")
             }
+
+            DittoLogger.setLogFileURL(logsDirectory.appendingPathComponent(logFileName))
         }
     }
 }

--- a/iOS/DittoChat/Screens/ChatScreen/ChatScreen.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/ChatScreen.swift
@@ -43,7 +43,9 @@ struct ChatScreen: View {
                         }
                     }
                 }
+#if !os(visionOS)
                 .scrollDismissesKeyboard(.interactively)
+#endif
                 .onAppear {
                     DispatchQueue.main.async {
                         scrollToBottom(proxy: proxy)

--- a/iOS/DittoChat/Screens/CodeScanner/ScannerView.swift
+++ b/iOS/DittoChat/Screens/CodeScanner/ScannerView.swift
@@ -6,6 +6,8 @@
 //
 //  Copyright © 2023 DittoLive Incorporated. All rights reserved.
 
+// AVMetadataObject is unavailable in visionOS
+#if !os(visionOS)
 import CodeScanner
 import SwiftUI
 
@@ -16,8 +18,9 @@ struct ScannerView: View {
     @State private var scanFailed: Bool = false
     var successAction: (String) -> Void = {_ in}
     var failAction: (String) -> Void = {_ in}
+
     var scanError: ScanError? = nil
-    
+
     var body: some View {
         VStack {
             CodeScannerView(codeTypes: [.qr], completion: handleScan)
@@ -72,3 +75,5 @@ struct ScannerView_Previews: PreviewProvider {
         ScannerView()
     }
 }
+
+#endif

--- a/iOS/DittoChat/Screens/MessageEditView/MessageEditView.swift
+++ b/iOS/DittoChat/Screens/MessageEditView/MessageEditView.swift
@@ -79,7 +79,9 @@ struct MessageEditView: View {
                     }
                     
                 }
+#if !os(visionOS)
                 .scrollDismissesKeyboard(.interactively)
+#endif
                 .onAppear {
                     DispatchQueue.main.async {
                         withAnimation {

--- a/iOS/DittoChat/Screens/RoomsListScreen/RoomsListScreen.swift
+++ b/iOS/DittoChat/Screens/RoomsListScreen/RoomsListScreen.swift
@@ -56,6 +56,7 @@ struct RoomsListScreen: View {
         .sheet(isPresented: $viewModel.presentProfileScreen) {
             ProfileScreen()
         }
+#if !os(visionOS)
         .sheet(isPresented: $viewModel.presentScannerView) {
             ScannerView(
                 successAction: { code in
@@ -63,6 +64,7 @@ struct RoomsListScreen: View {
                 }
             )
         }
+#endif
         .sheet(isPresented: $viewModel.presentCreateRoomScreen) {
             RoomEditScreen()
         }

--- a/iOS/DittoChat/Screens/SettingsScreen/SettingsScreen.swift
+++ b/iOS/DittoChat/Screens/SettingsScreen/SettingsScreen.swift
@@ -16,6 +16,7 @@ import DittoSwift
 import SwiftUI
 
 struct SettingsScreen: View {
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
     @StateObject var vm = SettingsScreenVM()
     @ObservedObject var dittoInstance = DittoInstance.shared
@@ -243,6 +244,17 @@ struct SettingsScreen: View {
             }// end List
             .listStyle(.insetGrouped)
             .navigationBarTitle(settingsTitleKey)
+            .toolbar(content: {
+                ToolbarItemGroup(placement: .navigationBarLeading) {
+                    if !vm.dismissDisabled {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Text(cancelTitleKey)
+                        }
+                    }
+                }
+            })
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/iOS/DittoChat/Screens/SettingsScreen/SettingsScreenVM.swift
+++ b/iOS/DittoChat/Screens/SettingsScreen/SettingsScreenVM.swift
@@ -10,6 +10,7 @@ import Combine
 import SwiftUI
 
 class SettingsScreenVM: ObservableObject {
+    @Published var dismissDisabled = false
     @Published var archivedPublicRooms: [Room] = []
     @Published var unReplicatedPublicRooms: [Room] = []
     @Published var archivedPrivateRooms: [Room] = []

--- a/iOS/DittoChat/Utilities/Utils.swift
+++ b/iOS/DittoChat/Utilities/Utils.swift
@@ -97,10 +97,10 @@ extension Bundle {
 
 extension CGFloat {
     static var screenWidth: CGFloat {
-        UIScreen.main.bounds.width
+        .infinity
     }
     static var screenHeight: CGFloat {
-        UIScreen.main.bounds.height
+        .infinity
     }
 }
 


### PR DESCRIPTION
This PR adds support for the visionOS platform.

This PR is stacked on top of #114 and #95 and will not be merged until those PRs land and official support is launched for visionOS (in 4.9?).

Uses `4.8.0-visionos-beta.1` releases of both [DittoSwiftPackage](https://github.com/getditto/DittoSwiftPackage/releases/tag/4.8.0-visionos-beta.1) and [DittoSwiftTools](https://github.com/getditto/DittoSwiftTools/releases/tag/4.8.0-visionos-beta.1)