### PR TITLE
Revert #94 `update qrCode to include more info`

### DIFF
--- a/iOS/DittoChat/Screens/ChatScreen/ChatScreenVM.swift
+++ b/iOS/DittoChat/Screens/ChatScreen/ChatScreenVM.swift
@@ -175,11 +175,8 @@ class ChatScreenVM: ObservableObject {
     // private room
     func shareQRCode() -> String? {
         if let collectionId = room.collectionId {
-            return "\(room.id)\n\(collectionId)\n\(room.messagesId)\n\(room.name)\n\(room.isPrivate)\n\(room.createdBy)\n\(room.createdOn)"
+            return "\(room.id)\n\(collectionId)\n\(room.messagesId)"
         }
         return nil
     }
 }
-
-
-


### PR DESCRIPTION
This PR simply reverts getditto/demoapp-chat#94
***

The reasons we need to revert it:
- The main purpose of #94 was to simplify the code.
- As a result, scanning QR codes from past versions or the Android app became unfeasible.
- Since we want to maintain backward compatibility, we will revert this PR.
- As an edge case, if a QR code from a device without a connection is scanned, the room content will not be displayed until the connection is resumed. However, since this is a very rare case, we have decided not to consider it.