### PR TITLE
Converting the iOS QR Scan to Join Private Rooms to DQL

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -135,7 +135,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-code-scanner:16.0.0")
 
     // Ditto
-    implementation("live.ditto:ditto:4.7.2")
+    implementation("live.ditto:ditto:4.7.4")
 
     // Load Presence Viewer from an .aar library file
     implementation fileTree(dir: "${rootDir}/android-libs", include: ["*.aar"])

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
@@ -317,7 +317,7 @@ class RepositoryImpl @Inject constructor(
                     results.items.map { item ->
                         val collectionId = item.value[collectionIdKey] as String
                         async {
-                            ditto.store.execute("SELECT * FROM $collectionId").items.map { Room(it.value) }
+                            ditto.store.execute("SELECT * FROM `$collectionId`").items.map { Room(it.value) }
                         }
                     }.map { it.await() }
                 }

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -969,8 +969,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/getditto/DittoSwiftTools.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.4.0;
+				kind = exactVersion;
+				version = 4.4.0;
 			};
 		};
 		14BF945B29786731001F672D /* XCRemoteSwiftPackageReference "CodeScanner" */ = {


### PR DESCRIPTION
Converted the iOS QR scan to join private rooms using the DQL syntax.
This should work without any behavior changes. I have tested it on my devices, and it worked as expected (scanned and joinned rooms on other devices).