### PR TITLE
Update Ditto SDK to 4.14.4

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -141,10 +141,10 @@ dependencies {
     implementation("com.google.android.gms:play-services-code-scanner:16.1.0")
 
     // Ditto
-    implementation("live.ditto:ditto:4.13.1")
+    implementation("live.ditto:ditto:4.14.3")
 
     // Ditto Tools
-    implementation("live.ditto:ditto-tools-android:5.0.1")
+    implementation("live.ditto:ditto-tools-android:5.0.2")
 
     // Date Time Library - the latest way to handle dates in Kotlin
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     implementation("com.google.android.gms:play-services-code-scanner:16.1.0")
 
     // Ditto
-    implementation("live.ditto:ditto:4.14.3")
+    implementation("live.ditto:ditto:4.14.4")
 
     // Ditto Tools
     implementation("live.ditto:ditto-tools-android:5.0.2")

--- a/Android/app/src/main/java/live/dittolive/chat/DittoHandler.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/DittoHandler.kt
@@ -72,14 +72,15 @@ class DittoHandler {
                     disableSyncWithV3()
                 }
 
-                // 💡WebSocket (cloud sync) has been disabled for this demo because it's shared among many users,
+                // 💡 WebSocket (cloud sync) has been disabled for this demo because it's shared among many users,
                 // and we don't want messages to get mixed up across public rooms.
                 //
                 /* ditto.updateTransportConfig {
                     it.connect.websocketUrls.add(BuildConfig.DITTO_WEBSOCKET_URL)
                 } */
 
-                // disable strict mode - allows for DQL with counters and objects as CRDT maps, must be called before startSync
+                // Disable strict mode so objects are treated as CRDT MAPs with field-level merging
+                // rather than REGISTERs with last-write-wins. Must be called before startSync.
                 // https://docs.ditto.live/dql/strict-mode
                 ditto.store.execute("ALTER SYSTEM SET DQL_STRICT_MODE = false")
 

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/Room.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/Room.kt
@@ -28,7 +28,6 @@ package live.dittolive.chat.data.model
 import androidx.compose.runtime.Immutable
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import live.ditto.DittoDocument
 import live.dittolive.chat.data.collectionIdKey
 import live.dittolive.chat.data.createdByKey
 import live.dittolive.chat.data.createdOnKey

--- a/Android/app/src/main/java/live/dittolive/chat/data/model/User.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/model/User.kt
@@ -25,7 +25,6 @@
 
 package live.dittolive.chat.data.model
 
-import live.ditto.DittoDocument
 import live.dittolive.chat.data.collectionIdKey
 import live.dittolive.chat.data.createdByKey
 import live.dittolive.chat.data.createdOnKey

--- a/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/data/repository/RepositoryImpl.kt
@@ -36,13 +36,8 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import live.ditto.Ditto
 import live.ditto.DittoAttachment
-import live.ditto.DittoCollection
-import live.ditto.DittoDocument
-import live.ditto.DittoLiveQuery
 import live.ditto.DittoQueryResultItem
-import live.ditto.DittoSortDirection
 import live.ditto.DittoStoreObserver
-import live.ditto.DittoSubscription
 import live.ditto.DittoSyncSubscription
 import live.dittolive.chat.DittoHandler.Companion.ditto
 import live.dittolive.chat.conversation.Message

--- a/Android/app/src/main/java/live/dittolive/chat/viewmodel/MainViewModel.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/viewmodel/MainViewModel.kt
@@ -331,9 +331,7 @@ class MainViewModel @Inject constructor(
                     val tempFile: File?
                     try {
                         tempFile = saveBitmapToTempFile(appContext, downsampledBitmap, quality)
-                        val collectionId = currentRoom.value.collectionID ?: DEFAULT_PUBLIC_ROOM_MESSAGES_COLLECTION_ID
-                        val collection = DittoHandler.ditto.store.collection(collectionId)
-                        val attachment = collection.newAttachment(
+                        val attachment = DittoHandler.ditto.store.newAttachment(
                             tempFile.inputStream(), mapOf(
                                 metadataFilenameKey to message.userId + "_thumbnail_" + timestamp + ".jpg",
                                 metadataFileformatKey to ".jpg",

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -985,7 +985,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.13.1;
+				minimumVersion = 4.14.3;
 			};
 		};
 		14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */ = {

--- a/iOS/DittoChat.xcodeproj/project.pbxproj
+++ b/iOS/DittoChat.xcodeproj/project.pbxproj
@@ -985,7 +985,7 @@
 			repositoryURL = "https://github.com/getditto/DittoSwiftPackage";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.14.3;
+				minimumVersion = 4.14.4;
 			};
 		};
 		14CADB5E293FF00700BED068 /* XCRemoteSwiftPackageReference "Fakery" */ = {

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "c68c60c68ca4783248466781fd7607e1e59af198",
-        "version" : "4.13.1"
+        "revision" : "61b203cffc6a85c1c0d0987d1833d62eca7c549c",
+        "version" : "4.14.3"
       }
     },
     {

--- a/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/DittoChat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getditto/DittoSwiftPackage",
       "state" : {
-        "revision" : "61b203cffc6a85c1c0d0987d1833d62eca7c549c",
-        "version" : "4.14.3"
+        "revision" : "909dec6b0089653057e630e11e621ec8b47927a8",
+        "version" : "4.14.4"
       }
     },
     {

--- a/iOS/DittoChat/Data/DataManager.swift
+++ b/iOS/DittoChat/Data/DataManager.swift
@@ -193,7 +193,7 @@ extension DataManager {
 
 extension DataManager {
     var sdkVersion: String {
-        DittoInstance.shared.ditto.sdkVersion
+        Ditto.version
     }
     
     var appInfo: String {

--- a/iOS/DittoChat/Data/DittoService.swift
+++ b/iOS/DittoChat/Data/DittoService.swift
@@ -30,18 +30,16 @@ class DittoInstance: ObservableObject {
         // 💡 WebSocket (cloud sync) has been disabled for this demo because it's shared among many users, and we don't want messages to get mixed up across public rooms.
         //
         /* ditto.updateTransportConfig { transportConfig in
-            // Set the Ditto Websocket URL
             transportConfig.connect.webSocketURLs.insert(Env.DITTO_WEBSOCKET_URL)
         } */
-
 
         do {
             // Disable sync with V3 Ditto
             try ditto.disableSyncWithV3()
-            // Disable avoid_redundant_bluetooth
             Task {
-                // disable strict mode - allows for DQL with counters and objects as CRDT maps, must be called before startSync
-                // https://docs.ditto.live/dql/strict-mode 
+                // Disable strict mode so objects are treated as CRDT MAPs with field-level merging
+                // rather than REGISTERs with last-write-wins. Must be called before startSync.
+                // https://docs.ditto.live/dql/strict-mode
                 try await ditto.store.execute(query: "ALTER SYSTEM SET DQL_STRICT_MODE = false")
             }
         } catch let error {
@@ -51,7 +49,7 @@ class DittoInstance: ObservableObject {
         // Prevent Xcode previews from syncing: non preview simulators and real devices can sync
         let isPreview: Bool = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
         if !isPreview {
-            try! ditto.startSync()
+            try! ditto.sync.start()
         }
         
         do {
@@ -68,8 +66,6 @@ class DittoService: ReplicatingDataInterface {
     @Published fileprivate private(set) var allPublicRooms: [Room] = []
     private var allPublicRoomsCancellable: AnyCancellable = AnyCancellable({})
     private var cancellables = Set<AnyCancellable>()
-    private var usersSubscription: DittoSubscription
-    
     // private in-memory stores of subscriptions for rooms and messages
     private var privateRoomSubscriptions = [String: DittoSyncSubscription]()
     private var privateRoomMessagesSubscriptions = [String: DittoSyncSubscription]()
@@ -82,17 +78,15 @@ class DittoService: ReplicatingDataInterface {
 
     init(privateStore: LocalDataInterface) {
         self.privateStore = privateStore
-        self.usersSubscription = ditto.store[usersKey].findAll().subscribe()
 
         createDefaultPublicRoom()
-        
+
         do {
             try ditto.sync.registerSubscription(query: "SELECT * FROM `\(publicRoomsCollectionId)`")
         } catch {
             print("Error subscribing to public rooms collection: \(error)")
         }
         
-        // kick off the public rooms findAll() liveQueryPublisher
         updateAllPublicRooms()
         
         // filter out archived public rooms, add subscriptions, set @Published publicRooms property
@@ -105,8 +99,6 @@ class DittoService: ReplicatingDataInterface {
                 rooms.sort { $0.createdOn > $1.createdOn }
                 
                 // add subscriptions in case a new one has come in
-                /* Note: maybe this could be more efficient, as all subscriptions are all
-                 re-initialized each time the collection[rooms] findAll query fires */
                 rooms.forEach {[weak self] room in
                     self?.addSubscriptions(for: room)
                 }
@@ -130,38 +122,38 @@ class DittoService: ReplicatingDataInterface {
 }
 
 ///  General Overview
-///  Public rooms are "public" by reason of the `findAll()` liveQueryPublisher on the `ditto.store["rooms"]` collection being
+///  Public rooms are "public" by reason of the DQL sync subscription on the "rooms" collection being
 ///  persisted in memory for the lifecycle of the app. All newly created public rooms on the mesh automatically replicate because of the
-///  `findAll()` query.
+///  `SELECT *` subscription.
 ///
-///  All rooms have thier own messages collection, named with a UUID string, stored in the `room.messagesId` property. This avoids
+///  All rooms have their own messages collection, named with a UUID string, stored in the `room.messagesId` property. This avoids
 ///  the Ditto db performance bottleneck of having a single "messages" collection, where queries for messages for a given room would
-///  require an all-table scan of all messages for every query. Each room can simply `findAll()` on its own messages collection.
+///  require an all-table scan of all messages for every query. Each room can simply subscribe to its own messages collection.
 ///
 ///  Private rooms each have their own room collection, named with a UUID string, stored in the `room.collectionId` property. This
 ///  makes the room "private" in that subscriptions to the room require knowing the UUID string collection name, whereas public rooms all
-///  reside, and are replicated from, the known "rooms" collection, i.e., `ditto.store["rooms"]`. Both private and public rooms each
-///  have their own messages collection, named with a UUID string, stored in the `room.messagesId` property.
+///  reside, and are replicated from, the known "rooms" collection. Both private and public rooms each have their own messages collection,
+///  named with a UUID string, stored in the `room.messagesId` property.
 ///
 /// Subscriptions Overview
-///  `DittoSubscription` objects subscribing to room and messages collections must be kept in memory througout the lifecycle
+///  `DittoSyncSubscription` objects subscribing to room and messages collections must be kept in memory throughout the lifecycle
 ///  of the app. This enables messages to replicate into the local Ditto db from the mesh, regardless of whether the user is currently
-///  viewing a given room. (For each navigation into a room, a liveQueryPublisher publishes messages for that room in real time for the
+///  viewing a given room. (For each navigation into a room, a registerObserver publishes messages for that room in real time for the
 ///  lifecycle of the view model that subscribes to the publisher. Even though the publisher is released after navigating out of the room, the
 ///  subscription object continues to replicate messages from the mesh. This ensures messages are always kept up to date.)
 ///
 ///  Subscriptions are added to subscription dictionary variables for every update of the `allPublicRooms` publisher after filtering out
-///  archived rooms, and for every update of the `privateStore.privateRoomPublisher`for private rooms.
+///  archived rooms, and for every update of the `privateStore.privateRoomPublisher` for private rooms.
 ///
-///  Public room `findAll()` subscriptions for their messages collection are created for every update of the `allPublicRooms`
-///  publisher (after filtering out archived public rooms), and stored  in the private `publicRoomMessageSubscriptions` variable
-///  of type `[String: DittoSubscription]`, where the key is the `room.id` and value is the subscription.
+///  Public room subscriptions for their messages collection are created for every update of the `allPublicRooms`
+///  publisher (after filtering out archived public rooms), and stored in the private `publicRoomMessagesSubscriptions` variable
+///  of type `[String: DittoSyncSubscription]`, where the key is the `room.id` and value is the subscription.
 ///
 ///  Private Rooms require subscriptions for both the room collection (`room.collectionId`) and its messages collection
 ///  (`room.messagesId`). These are stored in the private `privateRoomSubscriptions` and
-///  `privateRoomMessagesSubscriptions` variables, both of type `[String: DittoSubscription]`, where for the
+///  `privateRoomMessagesSubscriptions` variables, both of type `[String: DittoSyncSubscription]`, where for the
 ///  former the key is the `room.collectionId`, and the latter, the `room.messagesId`, and for both, the value is the
-///  `findAll()` subscription on the collection.
+///  subscription on the collection.
 ///
 ///  Subscriptions are added at launch for all non-archived public and private rooms via the publishers described above. The
 ///  `addSubscriptions` and `removeSubscriptions`functions are addtionally used by archiving and unarchiving functions,
@@ -760,12 +752,6 @@ extension DittoService {
         
         removeSubscriptions(for: room)
         evictPrivateRoom(room)
-        
-        //Deleting data (remove) is not supported in DQL
-        // additionally remove roomDoc, message collection, and collection itself from DB
-//        ditto.store[collectionId].findByID(room.id).remove()
-//        ditto.store[collectionsKey].findByID(room.messagesId).remove()
-//        ditto.store[collectionsKey].findByID(collectionId).remove()
 
         privateStore.deleteArchivedPrivateRoom(roomId: room.id)
     }


### PR DESCRIPTION
## Summary
- Update Ditto SDK from 4.13.1 to 4.14.4 on both iOS and Android
- Update Android Ditto Tools from 5.0.1 to 5.0.2
- Migrate deprecated/legacy Ditto APIs to modern equivalents (deprecations targeted by 4.14.x)

## Changes

**Version bumps:**
- Ditto SDK: 4.13.1 → 4.14.4 (iOS + Android)
- ditto-tools-android: 5.0.1 → 5.0.2
- iOS DittoSwiftTools: already at latest (9.0.1)

**iOS deprecation fixes:**
- `ditto.startSync()` → `ditto.sync.start()`
- `ditto.sdkVersion` → `Ditto.version`

**Legacy API migration:**
- iOS: Removed legacy `store[collection].findAll().subscribe()` — already covered by DQL `sync.registerSubscription()` in DittoInstance
- Android: `store.collection(id).newAttachment()` → `store.newAttachment()`

**Cleanup:**
- Removed unused legacy imports on Android (`DittoDocument`, `DittoLiveQuery`, `DittoSortDirection`, `DittoCollection`, `DittoSubscription`)
- Removed commented-out `findByID().remove()` calls on iOS
- Fixed DQL_STRICT_MODE comments to accurately describe MAP vs REGISTER behavior
- Updated doc comments from legacy `findAll()` terminology to DQL

## Deferred to a future SDK 5.0 upgrade PR

4.14.4 surfaces a coordinated set of "removed in SDK 5.0" deprecation warnings. These are **intentionally not addressed here** — they belong with the SDK 5.0 upgrade work, which involves a non-trivial init-path migration:

- iOS: `Ditto.init(identity:persistenceDirectory:)` → `Ditto.open(config:)` / `Ditto.openSync(config:)`
- iOS: `disableSyncWithV3()` (V3 sync no longer supported)
- iOS: `DittoAttachmentToken` + `fetchAttachmentPublisher(attachmentToken:)` → dictionary-based `[String: Any]` token APIs
- Android: `DittoIdentity`, `DittoIdentity.OnlinePlayground`, `DefaultAndroidDittoDependencies`, `Ditto(dependencies, identity)` constructor → `DittoConfig` / `DittoAndroidConfig` + `Ditto.open(config)` / `Ditto.openSync(config)`