### PR TITLE
Migrate ditto.live links to ditto.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This chat room demo showcases public and private chat rooms using Ditto.
 
 Powered by [Ditto](https://ditto.live/).
 
-For support, please contact Ditto Support (<support@ditto.live>).
+For support, please contact Ditto Support (<support@ditto.com>).
 
 - [Video Demo]() - pending
 - [iOS Download](https://apps.apple.com/us/app/dittochat/id1450111256)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Internet-less cross platform chat application
 
 This chat room demo showcases public and private chat rooms using Ditto.
 
-Powered by [Ditto](https://ditto.live/).
+Powered by [Ditto](https://www.ditto.com/).
 
 For support, please contact Ditto Support (<support@ditto.com>).
 


### PR DESCRIPTION
## Summary
- Updates README support contact from `support@ditto.live` to `support@ditto.com`.
- Updates Powered-by-Ditto link from `https://ditto.live/` to `https://www.ditto.com/`.