### PR TITLE
Android: target Android 16 (API 36) for Google Play compliance

### DIFF
--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -33,12 +33,12 @@ def dittoEnv(String key) {
 
 android {
     namespace "live.dittolive.chat"
-    compileSdk 35
+    compileSdk 36
 
     defaultConfig {
         applicationId "live.dittolive.chat"
         minSdk 29
-        targetSdk 35
+        targetSdk 36
         versionCode 37
         versionName "1"
 


### PR DESCRIPTION
## Problem
Google Play requires an app to target within one year of the latest Android release to keep publishing updates. demoapp-chat targets Android 15 (API 35), which becomes non-compliant on **2026-08-30** — after that, app updates can't be published.

## Solution
Bump `compileSdk` and `targetSdk` 35 → 36 (Android 16). Builds cleanly on the existing AGP 8.9.2, so no AGP or other changes are needed.

## ⚠️ Testing note — edge-to-edge (please verify on-device)
**Not yet tested by me or the author** — flagging honestly.

Targeting API 36 makes **edge-to-edge display mandatory**: Android 15 (API 35) began enforcing it by default, and Android 16 (API 36) removes the temporary `windowOptOutEdgeToEdgeEnforcement` opt-out. This app has no opt-out flag and already sets transparent system bars, so on 36 it draws fully edge-to-edge with no escape hatch. This is a common gotcha on a target-SDK bump.

The app *does* apply insets in several places (`systemBarsPadding`, `navigationBarsPadding`, `imePadding`, `windowInsetsTopHeight`), so it may be fine — but nothing here has been run on a device/emulator yet. Reviewers should check for content drawn under the status/navigation bars on API 36, specifically:
- Conversation screen: message list top, and the message input bar above the nav bar / IME.
- Navigation drawer header, and the Profile / Edit Profile screens.
- The hardcoded `WindowInsets(top = 90.dp)` offset in `Conversation.kt` — a magic value that may not hold across devices/inset sizes.
