### PR TITLE
Enable Dependabot for automated Ditto SDK update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,12 @@ multi-ecosystem-groups:
     schedule:
       interval: "weekly"
 updates:
-  # Android — Gradle (com.ditto / live.ditto artifacts)
+  # Android — Gradle (com.ditto artifacts: SDK + tools)
   - package-ecosystem: "gradle"
     directory: "/Android"
     multi-ecosystem-group: "ditto"
     patterns:
       - "com.ditto:*"
-      - "live.ditto:*"
 
   # iOS — Swift Package Manager via the Xcode project
   - package-ecosystem: "swift"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ multi-ecosystem-groups:
     schedule:
       interval: "weekly"
 updates:
-  # Android — Gradle (com.ditto artifacts: SDK + tools)
+  # Android — Gradle (com.ditto: SDK + tools)
   - package-ecosystem: "gradle"
     directory: "/Android"
     multi-ecosystem-group: "ditto"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+# Scoped to Ditto's first-party packages (SDK, DittoTools, and any future ones)
+# via wildcards, so their updates arrive as PRs without noise from third-party deps.
+version: 2
+updates:
+  # Android (Gradle) — all com.ditto / live.ditto artifacts
+  - package-ecosystem: "gradle"
+    directory: "/Android"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "com.ditto:*"
+      - dependency-name: "live.ditto:*"
+    commit-message:
+      prefix: "deps"
+
+  # iOS (Swift Package Manager, resolved through the Xcode project) — all Ditto* packages
+  - package-ecosystem: "swift"
+    directory: "/iOS"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "Ditto*"
+    commit-message:
+      prefix: "deps"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,24 @@
 # Dependabot — automated update PRs for Ditto first-party packages only
-# (SDK + tools), both platforms. https://docs.github.com/code-security/dependabot
+# (SDK + tools). Both platforms are combined into ONE PR per release via a
+# multi-ecosystem group. https://docs.github.com/code-security/dependabot
 # iOS uses the Xcode project's SwiftPM pins and needs a committed Package.resolved.
 version: 2
+multi-ecosystem-groups:
+  ditto:
+    schedule:
+      interval: "weekly"
 updates:
   # Android — Gradle (com.ditto / live.ditto artifacts)
   - package-ecosystem: "gradle"
     directory: "/Android"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-name: "com.ditto:*"
-      - dependency-name: "live.ditto:*"
-    commit-message:
-      prefix: "deps"
+    multi-ecosystem-group: "ditto"
+    patterns:
+      - "com.ditto:*"
+      - "live.ditto:*"
 
   # iOS — Swift Package Manager via the Xcode project
   - package-ecosystem: "swift"
     directory: "/iOS"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-name: "ditto*"
-    commit-message:
-      prefix: "deps"
+    multi-ecosystem-group: "ditto"
+    patterns:
+      - "ditto*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates
-# Scoped to Ditto's first-party packages (SDK, DittoTools, and any future ones)
-# via wildcards, so their updates arrive as PRs without noise from third-party deps.
+# Dependabot — automated update PRs for Ditto first-party packages only
+# (SDK + tools), both platforms. https://docs.github.com/code-security/dependabot
+# iOS uses the Xcode project's SwiftPM pins and needs a committed Package.resolved.
 version: 2
 updates:
-  # Android (Gradle) — all com.ditto / live.ditto artifacts
+  # Android — Gradle (com.ditto / live.ditto artifacts)
   - package-ecosystem: "gradle"
     directory: "/Android"
     schedule:
@@ -14,12 +14,12 @@ updates:
     commit-message:
       prefix: "deps"
 
-  # iOS (Swift Package Manager, resolved through the Xcode project) — all Ditto* packages
+  # iOS — Swift Package Manager via the Xcode project
   - package-ecosystem: "swift"
     directory: "/iOS"
     schedule:
       interval: "weekly"
     allow:
-      - dependency-name: "Ditto*"
+      - dependency-name: "ditto*"
     commit-message:
       prefix: "deps"


### PR DESCRIPTION
## Problem
Ditto ships updates to its SDK and tooling frequently, but bumping them in this repo is entirely manual today. The v5 upgrade was a painful manual effort — this keeps future first-party updates from drifting the same way.

## Solution
Add `.github/dependabot.yml` so Dependabot opens a PR whenever any **Ditto first-party** package publishes a release — the SDK, DittoTools, and any future ones — scoped via wildcards on **both platforms**, checked weekly:
- **Android (Gradle):** `com.ditto:*`, `live.ditto:*`
- **iOS (Swift / Xcode SwiftPM):** `Ditto*` — Dependabot added `.xcodeproj` + `Package.resolved` support in March 2026 ([changelog](https://github.blog/changelog/2026-03-31-dependabot-now-supports-xcode-projects-using-swiftpm-with-xcodeproj-manifests/)), so our Xcode-project SPM setup is covered.

### Notes
- Dependabot reads its config only from the **default branch**, so this activates once it reaches `main`. It's intentionally stacked on the v5 work (which is already done, just pending GA tools) — this is meant to take over maintenance *after* that lands, not to touch the v5 upgrade itself.
- The Swift `dependency-name` filter (`Ditto*`) matches package names (`DittoSwiftPackage`, `DittoSwiftTools`); worth a sanity check on the first run in case Dependabot names them differently.
