### PR TITLE
Fix Android edge-to-edge inset handling

### DIFF
--- a/Android/app/src/main/java/live/dittolive/chat/NavActivity.kt
+++ b/Android/app/src/main/java/live/dittolive/chat/NavActivity.kt
@@ -28,6 +28,7 @@ package live.dittolive.chat
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberDrawerState
@@ -38,6 +39,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidViewBinding
@@ -173,7 +175,10 @@ class NavActivity: AppCompatActivity() {
                                     dittoSdkVersion = "Ditto SDK ver "+ dittoSdkVersion,
                                     viewModel = viewModel
                                 ) {
-                                    AndroidViewBinding(NavHostBinding::inflate)
+                                    AndroidViewBinding(
+                                        factory = NavHostBinding::inflate,
+                                        modifier = Modifier.safeDrawingPadding()
+                                    )
                                 }
                             }
 


### PR DESCRIPTION
## Summary

- apply safe drawing insets at the Compose/View boundary around the Fragment navigation host
- keep interactive content clear of system bars and display cutouts on edge-to-edge Android versions

## Before / After

| Before | After |
| :---: | :---: |
| <img width="1080" height="420" alt="android-edge-to-edge-before-crop" src="https://github.com/user-attachments/assets/5b62a7d6-ae48-401c-8a88-381059258258" /> | <img width="1080" height="420" alt="android-edge-to-edge-after-crop" src="https://github.com/user-attachments/assets/9c4ebe8b-73cf-469e-88e1-af96ceaebbff" /> |
| The app toolbar is laid out from `y=0`, overlapping the status bar and camera cutout area. | The app toolbar starts below the `132px` top safe inset. |

## Testing

- manual Pixel 6a verification on Android 16 / API 36: nav host moved from `y=0` to the `132px` top safe inset and ends at the `2337px` navigation-bar boundary

## Lint

- `./gradlew lintDebug` reaches lint but fails on the existing `CoarseFineLocation` error in `AndroidManifest.xml:41` (1 error, 108 warnings); this PR does not modify the manifest
